### PR TITLE
feat: reports page, unified bulk-update endpoint, IMAP multi-folder

### DIFF
--- a/taxops/app.py
+++ b/taxops/app.py
@@ -17,6 +17,7 @@ from flask import (
 import json
 import io
 import logging
+import math
 import secrets
 import shutil
 import sqlite3
@@ -24,10 +25,13 @@ import tempfile
 import time
 from urllib.parse import urlencode
 
+import re as _re
+
 from config import (
     APP_ENV,
     DB_PATH,
     DRAKE_FOLDER_STRUCTURE_ENABLED,
+    INTAKE_AUTO_DISCOUNT,
     KNOWN_PROMOTIONAL_DOMAINS,
     MASS_MAILING_PREFIXES,
     MULTIYEAR_AGI_PERCENT_THRESHOLD,
@@ -89,12 +93,13 @@ app.config["TEMPLATES_AUTO_RELOAD"] = app.debug
 app.config["APP_VERSION"] = taxops_asset_cache_version()
 
 # SEC-3: session cookie hardening + lifetime.
-# SESSION_COOKIE_SECURE is intentionally left False here because the office LAN
-# does not currently terminate HTTPS in front of this server.  Enable it once a
-# reverse proxy or load balancer provides TLS (see issue SEC-3).
+# SESSION_COOKIE_SECURE is gated on TAXOPS_HTTPS_ENABLED because the office LAN
+# currently uses plain HTTP.  Set TAXOPS_HTTPS_ENABLED=true once a reverse proxy
+# or load balancer terminates TLS in front of this server.
 app.config.update(
     SESSION_COOKIE_HTTPONLY=True,
     SESSION_COOKIE_SAMESITE="Lax",
+    SESSION_COOKIE_SECURE=os.environ.get("TAXOPS_HTTPS_ENABLED", "false").lower() == "true",
     PERMANENT_SESSION_LIFETIME=timedelta(hours=12),
 )
 
@@ -151,10 +156,12 @@ from routes.documents import documents_bp
 from routes.email_review import email_review_bp
 from routes.accounting import accounting_bp
 from routes.users import users_bp
+from routes.reports import reports_bp
 app.register_blueprint(documents_bp)
 app.register_blueprint(email_review_bp)
 app.register_blueprint(accounting_bp)
 app.register_blueprint(users_bp)
+app.register_blueprint(reports_bp)
 
 
 # REL-4: Flask g-based DB helper — lets routes use get_db() and have the connection
@@ -584,7 +591,9 @@ def _enrich(r: dict) -> dict:
     first = r.get("first_name") or ""
     last  = r.get("last_name")  or ""
     r["name_full"] = r.get("display_name") or (f"{last}, {first}".strip(", ") if first else last)
-    r["forms"]        = _form_badges(r)
+    r["forms"]         = _form_badges(r)
+    # Pre-compute preparer display label so the AJAX row renderer doesn't need a server roundtrip.
+    r["processor_label"] = preparer_list_label(r.get("processor") or "")
     intake_dt = _parse_iso_date(r.get("intake_date"))
     completion_dt = _parse_iso_date(r.get("logout_date")) or _parse_iso_date(r.get("ack_date"))
     r["cycle_days"] = (
@@ -740,11 +749,137 @@ def query_returns(filters: dict | None = None) -> list[dict]:
             params.extend([qp, qp, qp])
 
     where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
-    sql   = f"{_SELECT} {where} ORDER BY CASE WHEN r.log_number IS NULL OR r.log_number='' THEN 1 ELSE 0 END, CAST(r.log_number AS INTEGER), r.id"
+    order = "ORDER BY CASE WHEN r.log_number IS NULL OR r.log_number='' THEN 1 ELSE 0 END, CAST(r.log_number AS INTEGER), r.id"
+    sql   = f"{_SELECT} {where} {order}"
 
     try:
         rows = conn.execute(sql, params).fetchall()
         return [_enrich(dict(r)) for r in rows]
+    finally:
+        conn.close()
+
+
+def query_returns_paginated(filters: dict | None = None, *, page: int = 1, per_page: int = 50) -> tuple[list[dict], int]:
+    """Return (rows_for_page, total_count) for dashboard pagination.
+
+    Runs two queries: a COUNT and a paginated SELECT.  Both share the same
+    WHERE clause built from *filters*, so the count always reflects the full
+    matching set regardless of the current page.
+    """
+    conn = get_connection()
+    f = filters or {}
+    clauses: list[str] = []
+    params:  list      = []
+
+    year = f.get("year") or date.today().year
+    clauses.append(
+        "(strftime('%Y', r.intake_date) = ? OR "
+        "(r.intake_date IS NULL AND r.tax_year = ?))"
+    )
+    params.append(str(year))
+    params.append(year - 1)
+
+    if f.get("status"):
+        statuses = f["status"] if isinstance(f["status"], list) else [f["status"]]
+        statuses = [s for s in statuses if s]
+        if statuses:
+            clauses.append(f"r.client_status IN ({','.join('?' for _ in statuses)})")
+            params.extend(statuses)
+
+    if f.get("processor"):
+        pvals = preparer_filter_match_values(f["processor"])
+        if pvals:
+            clauses.append("r.processor IN (" + ",".join("?" for _ in pvals) + ")")
+            params.extend(pvals)
+
+    if f.get("balance_due"):
+        clauses.append(
+            "(p.total_fee IS NOT NULL AND COALESCE(p.fee_paid,0) < p.total_fee)"
+        )
+    if f.get("late_intake"):
+        clauses.append(
+            "(r.intake_date IS NOT NULL AND ("
+            "CAST(substr(r.intake_date,6,2) AS INTEGER) > 4 OR "
+            "(CAST(substr(r.intake_date,6,2) AS INTEGER) = 4 AND CAST(substr(r.intake_date,9,2) AS INTEGER) >= 1)"
+            "))"
+        )
+    if f.get("slow_cycle"):
+        clauses.append(
+            "(r.intake_date IS NOT NULL AND "
+            "(r.logout_date IS NOT NULL OR r.ack_date IS NOT NULL) AND "
+            "(julianday(COALESCE(r.logout_date, r.ack_date)) - julianday(r.intake_date)) >= ?)"
+        )
+        params.append(SLOW_CYCLE_DAYS)
+
+    if f.get("form"):
+        form_col = f["form"]
+        allowed = {
+            "form_1040", "sched_a_d", "sched_c", "sched_e",
+            "form_1120", "form_1120s", "form_1065_llc",
+            "corp_officer", "business_owner", "form_990_1041",
+            "is_amended", "has_w7", "is_extension",
+        }
+        if form_col in allowed:
+            if form_col in ("is_amended", "has_w7", "is_extension"):
+                clauses.append(f"r.{form_col} = 1")
+            else:
+                clauses.append(f"rf.{form_col} = 1")
+
+    if f.get("reject_contact"):
+        st_raw = f.get("status")
+        st_list = st_raw if isinstance(st_raw, list) else ([st_raw] if st_raw else [])
+        if not (st_list and "REJECTED" not in st_list):
+            rc = (f["reject_contact"] or "").strip().lower()
+            clauses.append("r.client_status = 'REJECTED'")
+            if rc == "needs_followup":
+                clauses.append(
+                    "(r.contact_status IS NULL OR r.contact_status = '' OR "
+                    "r.contact_status IN ('not_contacted','follow_up_needed'))"
+                )
+            elif rc in CONTACT_STATUS_VALUES:
+                if rc == "not_contacted":
+                    clauses.append(
+                        "(r.contact_status IS NULL OR r.contact_status = '' OR r.contact_status = 'not_contacted')"
+                    )
+                else:
+                    clauses.append("r.contact_status = ?")
+                    params.append(rc)
+
+    if f.get("q"):
+        q = f["q"].strip()
+        if q.isdigit():
+            clauses.append("r.log_number = ?")
+            params.append(q)
+        else:
+            qp = f"%{q.lower()}%"
+            clauses.append(
+                "(lower(c.last_name) LIKE ? OR lower(c.first_name) LIKE ? OR lower(COALESCE(c.display_name,'')) LIKE ?)"
+            )
+            params.extend([qp, qp, qp])
+
+    where = ("WHERE " + " AND ".join(clauses)) if clauses else ""
+    order = "ORDER BY CASE WHEN r.log_number IS NULL OR r.log_number='' THEN 1 ELSE 0 END, CAST(r.log_number AS INTEGER), r.id"
+
+    per_page = min(100, max(1, int(per_page)))
+    page     = max(1, int(page))
+    offset   = (page - 1) * per_page
+
+    # COUNT query — same WHERE, no ORDER/LIMIT
+    count_sql = (
+        "SELECT COUNT(*) n "
+        "FROM returns r "
+        "JOIN clients c ON c.id = r.client_id "
+        "LEFT JOIN payments p ON p.return_id = r.id "
+        "LEFT JOIN return_forms rf ON rf.return_id = r.id "
+        f"{where}"
+    )
+
+    paginated_sql = f"{_SELECT} {where} {order} LIMIT ? OFFSET ?"
+
+    try:
+        total_count = conn.execute(count_sql, params).fetchone()["n"]
+        rows = conn.execute(paginated_sql, params + [per_page, offset]).fetchall()
+        return [_enrich(dict(r)) for r in rows], total_count
     finally:
         conn.close()
 
@@ -895,6 +1030,7 @@ def get_totals(year: int) -> dict:
         FROM returns r
         LEFT JOIN payments p ON p.return_id = r.id
         WHERE (strftime('%Y', r.intake_date) = ? OR (r.intake_date IS NULL AND r.tax_year = ?))
+          AND UPPER(COALESCE(r.client_status,'')) != 'CANCELLED'
         """,
         (str(year), year - 1),
     ).fetchone()
@@ -1148,7 +1284,9 @@ def login():
         password = request.form.get("password") or ""
         user = _authenticate_user(username, password)
         if user is _AUTH_LOCKED:
-            # SEC-7: account locked — same UX string as bad-password to avoid info leak.
+            # SEC-7: constant-time failure — sleep before returning so a timing oracle
+            # cannot distinguish a lockout response from a bcrypt verification.
+            time.sleep(0.2)
             error = "Invalid username or password."
         elif user:
             session.permanent = True  # SEC-3: enforce PERMANENT_SESSION_LIFETIME (12 h)
@@ -1165,6 +1303,9 @@ def login():
             next_url = request.args.get("next") or url_for("dashboard")
             return redirect(next_url)
         else:
+            # SEC-7: constant-time failure — sleep before returning so a timing oracle
+            # cannot distinguish an unknown-user response from a bcrypt verification.
+            time.sleep(0.2)
             error = "Invalid username or password."
     return render_template("login.html", error=error)
 
@@ -1462,6 +1603,69 @@ def health():
     return jsonify(body), (200 if db_ok else 503)
 
 
+@app.get("/api/dashboard/returns")
+@login_required
+def api_dashboard_returns():
+    """Paginated dashboard returns for AJAX navigation (Section 3 — dashboard pagination).
+
+    Accepts the same filter query-string parameters as GET / plus `page` and `per_page`.
+    Returns JSON with the paginated row list and total-count metadata so the client
+    can update the tbody and pagination controls without a full page reload.
+    """
+    year     = int(request.args.get("year", date.today().year))
+    page     = max(1, int(request.args.get("page", 1)))
+    per_page = min(100, max(1, int(request.args.get("per_page", 50))))
+    filters  = {
+        "year":           year,
+        "status":         request.args.getlist("status") or None,
+        "processor":      request.args.get("processor"),
+        "balance_due":    request.args.get("balance_due"),
+        "late_intake":    request.args.get("late_intake"),
+        "slow_cycle":     request.args.get("slow_cycle"),
+        "form":           request.args.get("form"),
+        "reject_contact": request.args.get("reject_contact"),
+        "q":              request.args.get("q"),
+    }
+    rows, total_count = query_returns_paginated(filters, page=page, per_page=per_page)
+    total_pages = max(1, math.ceil(total_count / per_page))
+    return jsonify({
+        "returns":     rows,
+        "total_count": total_count,
+        "page":        page,
+        "per_page":    per_page,
+        "total_pages": total_pages,
+        "has_next":    page < total_pages,
+        "has_prev":    page > 1,
+    })
+
+
+@app.get("/api/notifications/unread-documents")
+@login_required
+def api_unread_documents():
+    """Section 4 — document arrival badge.
+
+    Returns the count of email-sourced documents that have not yet been typed
+    (doc_type = 'unknown') and have not been soft-deleted.  This is the lightweight
+    query that drives the amber badge on the Email Review nav item.
+    """
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) n FROM return_documents "
+            "WHERE source = 'email' AND doc_type = 'unknown' AND is_deleted = 0"
+        ).fetchone()
+        unconfirmed = conn.execute(
+            "SELECT COUNT(*) n FROM return_documents "
+            "WHERE match_confirmed = 0 AND is_deleted = 0"
+        ).fetchone()
+        return jsonify({
+            "count": row["n"],
+            "unconfirmed_matches": unconfirmed["n"],
+        })
+    finally:
+        conn.close()
+
+
 # ── Saved dashboard filters (Epic #85, FILTER-1…FILTER-6) ─────────────────────
 
 
@@ -1671,6 +1875,10 @@ def dashboard():
             if _dashboard_saved_filter_meaningful(fd_clean):
                 return redirect("/?" + _dashboard_filter_query_string(fd_clean, year))
 
+    # Dashboard pagination — cap per_page at 100, default 50.
+    page     = max(1, int(request.args.get("page", 1)))
+    per_page = min(100, max(1, int(request.args.get("per_page", 50))))
+
     filters = {
         "year":        year,
         "status":      request.args.getlist("status") or None,
@@ -1682,13 +1890,20 @@ def dashboard():
         "reject_contact": request.args.get("reject_contact"),
         "q":           request.args.get("q"),
     }
-    returns = query_returns(filters)
+    returns, total_count = query_returns_paginated(filters, page=page, per_page=per_page)
+    total_pages = max(1, math.ceil(total_count / per_page))
     ctx = base_ctx(year)
     snap = _dashboard_filter_snapshot_from_current_request(year)
     ctx.update({
         "active_page":                         "dashboard",
         "returns":                             returns,
         "filters":                             filters,
+        "total_count":                         total_count,
+        "page":                                page,
+        "per_page":                            per_page,
+        "total_pages":                         total_pages,
+        "has_next":                            page < total_pages,
+        "has_prev":                            page > 1,
         "saved_dashboard_filters":             _saved_dashboard_filters_payload(uname, year),
         "can_publish_shared_dashboard_filters": can_publish_shared_dashboard_filters(),
         "dashboard_current_filter_snapshot":   snap,
@@ -1714,6 +1929,11 @@ def return_detail(return_id: int):
         "SELECT * FROM missing_docs WHERE return_id=? ORDER BY is_resolved, created_at",
         (return_id,)
     ).fetchall()
+    # DEP-1/DEP-3: load active dependents for return detail
+    dependents = conn.execute(
+        "SELECT * FROM dependents WHERE return_id=? AND is_deleted=0 ORDER BY id",
+        (return_id,)
+    ).fetchall()
     conn.close()
     notes_payload = [dict(n) for n in notes]
     if privacy_mode_enabled():
@@ -1728,6 +1948,7 @@ def return_detail(return_id: int):
         "notes":          notes_payload,
         "events":         [dict(e) for e in events],
         "missing_docs":   [dict(d) for d in missing_docs],
+        "dependents":     [dict(d) for d in dependents],
         "contact_labels": CONTACT_LABELS,
         "drake_enabled":  bool(DRAKE_FOLDER_STRUCTURE_ENABLED),
     })
@@ -2357,12 +2578,14 @@ def payments():
 @login_required
 def intake():
     if request.method == "GET":
+        from config import INTAKE_SUGGESTED_UPCHARGE_PCT as _upc
         ctx = base_ctx()
         ctx.update({
             "active_page": "intake",
             "today": date.today().isoformat(),
             "error": None,
             "habit_profile": None,
+            "intake_suggested_upcharge_pct": _upc,
         })
         return render_template("intake.html", **ctx)
 
@@ -2374,8 +2597,10 @@ def intake():
     last_name  = (f.get("last_name") or "").strip().upper()
     first_name = (f.get("first_name") or "").strip().upper()
     if not last_name:
+        from config import INTAKE_SUGGESTED_UPCHARGE_PCT as _upc
         ctx = base_ctx()
-        ctx.update({"active_page": "intake", "today": today_iso, "error": "Last name is required.", "prefill": {}})
+        ctx.update({"active_page": "intake", "today": today_iso, "error": "Last name is required.",
+                    "prefill": {}, "intake_suggested_upcharge_pct": _upc})
         return render_template("intake.html", **ctx), 400
 
     def _v(key):
@@ -2393,6 +2618,14 @@ def intake():
         val = f.get(key, "").strip()
         return int(val) if val.isdigit() else None
 
+    def _ssn_last4_from_full(field_name: str) -> str | None:
+        """Extract last 4 digits from a full SSN field (XXX-XX-XXXX). Never logged."""
+        raw = f.get(field_name, "").strip()
+        digits = _re.sub(r"\D", "", raw)
+        if len(digits) >= 4:
+            return digits[-4:]
+        return digits if digits else None
+
     conn = get_connection()
     try:
         tax_year = _i("tax_year") or date.today().year
@@ -2406,6 +2639,10 @@ def intake():
 
         # ── Client — insert new or update existing (re-intake) ────────────────
         existing_client_id = _i("client_id")
+        # INTAKE-2: derive ssn_last4 from full SSN field (never stored in full)
+        taxpayer_ssn_last4 = _ssn_last4_from_full("ssn_full")
+        spouse_ssn_last4   = _ssn_last4_from_full("spouse_ssn_full")
+
         if existing_client_id:
             conn.execute(
                 """
@@ -2422,7 +2659,7 @@ def intake():
                 WHERE id=?
                 """,
                 (
-                    last_name, first_name, _v("ssn_last4"),
+                    last_name, first_name, taxpayer_ssn_last4,
                     (_v("spouse_last_name") or "").upper() or None,
                     (_v("spouse_first_name") or "").upper() or None,
                     _v("taxpayer_dob"), _v("spouse_dob"),
@@ -2455,7 +2692,7 @@ def intake():
                 ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
                 """,
                 (
-                    last_name, first_name, _v("ssn_last4"),
+                    last_name, first_name, taxpayer_ssn_last4,
                     (_v("spouse_last_name") or "").upper() or None,
                     (_v("spouse_first_name") or "").upper() or None,
                     _v("taxpayer_dob"), _v("spouse_dob"),
@@ -2532,6 +2769,11 @@ def intake():
         )
 
         # ── Payment ───────────────────────────────────────────────────────────
+        # INTAKE-8: apply auto-discount for new clients (no prior return)
+        discount_val = _n("discount_amount")
+        if existing_client_id is None and discount_val is None:
+            discount_val = float(INTAKE_AUTO_DISCOUNT) if INTAKE_AUTO_DISCOUNT else None
+
         conn.execute(
             """
             INSERT INTO payments (
@@ -2545,7 +2787,7 @@ def intake():
                 _n("total_fee"), _n("fee_paid"),
                 _v("receipt_number"), _v("receipt2_number"),
                 _n("accounting_fee"), _n("w7_fee"), _n("form_1099_fee"), _n("license_fee"),
-                _n("reprocess_fee"), _n("discount_amount"), _n("special_discount"),
+                _n("reprocess_fee"), discount_val, _n("special_discount"),
                 _n("down_payment"),
             ),
         )
@@ -2559,8 +2801,8 @@ def intake():
             conn.execute(
                 """
                 INSERT INTO dependents
-                  (return_id, full_name, ssn_last4, relationship, date_of_birth, medi_cal, created_at)
-                VALUES (?,?,?,?,?,?,?)
+                  (return_id, full_name, ssn_last4, relationship, date_of_birth, medi_cal, on_medicare, created_at)
+                VALUES (?,?,?,?,?,?,?,?)
                 """,
                 (
                     return_id, name,
@@ -2568,6 +2810,7 @@ def intake():
                     _v(f"dep_rel_{i}"),
                     _v(f"dep_dob_{i}"),
                     1 if f.get(f"dep_medicaid_{i}") else 0,
+                    1 if f.get(f"dep_medicare_{i}") else 0,
                     ts,
                 ),
             )
@@ -2791,25 +3034,47 @@ def _import_row(conn, row_data: dict, tax_year: int, ts: str, today_iso: str, st
         )
         return  # do not create return — wait for staff to resolve
     else:
-        # No match — create new client
-        conn.execute(
-            """INSERT INTO clients (last_name, first_name, referral_flag, referred_by,
-                                    prior_year_log, is_new_client, created_at, updated_at)
-               VALUES (?,?,?,?,?,1,?,?)""",
-            (
-                last_name, first_name,
-                1 if g("clients", "referral_flag") else 0,
-                normalize_string(g("clients", "referred_by")),
-                normalize_string(g("clients", "prior_year_log")),
-                ts, ts,
-            ),
-        )
-        client_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
-        # Add to cache so subsequent rows for the same new client match
-        if _client_cache is not None:
-            _client_cache.append({"id": client_id, "ln": last_name.upper(), "fn": (first_name or "").upper()})
-        stats["created"] = stats.get("created", 0) + 1
-        match_method = "new"
+        # Fuzzy returned nothing — try an exact SQL lookup before inserting a new row.
+        # This prevents duplicates for business names (NULL first_name) and handles
+        # cases where the in-memory cache was not populated (e.g. first row of a session).
+        if first_name:
+            _exact = conn.execute(
+                "SELECT id FROM clients WHERE lower(last_name)=lower(?) AND lower(first_name)=lower(?) LIMIT 1",
+                (last_name, first_name),
+            ).fetchone()
+        else:
+            _exact = conn.execute(
+                "SELECT id FROM clients WHERE lower(last_name)=lower(?) AND (first_name IS NULL OR first_name='') LIMIT 1",
+                (last_name,),
+            ).fetchone()
+
+        if _exact:
+            client_id = _exact[0]
+            conn.execute("UPDATE clients SET updated_at=? WHERE id=?", (ts, client_id))
+            if _client_cache is not None and not any(c["id"] == client_id for c in _client_cache):
+                _client_cache.append({"id": client_id, "ln": last_name.upper(), "fn": (first_name or "").upper()})
+            stats["updated"] = stats.get("updated", 0) + 1
+            match_method = "exact_fallback"
+        else:
+            # Genuinely new client
+            conn.execute(
+                """INSERT INTO clients (last_name, first_name, referral_flag, referred_by,
+                                        prior_year_log, is_new_client, created_at, updated_at)
+                   VALUES (?,?,?,?,?,1,?,?)""",
+                (
+                    last_name, first_name,
+                    1 if g("clients", "referral_flag") else 0,
+                    normalize_string(g("clients", "referred_by")),
+                    normalize_string(g("clients", "prior_year_log")),
+                    ts, ts,
+                ),
+            )
+            client_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+            # Add to cache so subsequent rows for the same new client match
+            if _client_cache is not None:
+                _client_cache.append({"id": client_id, "ln": last_name.upper(), "fn": (first_name or "").upper()})
+            stats["created"] = stats.get("created", 0) + 1
+            match_method = "new"
 
     # ── Match or create return ────────────────────────────────────────────────
     ret_year = tax_year
@@ -4009,6 +4274,75 @@ def api_returns_bulk_processor():
         conn.close()
 
 
+@app.post("/api/returns/bulk-update")
+@login_required
+def api_returns_bulk_update():
+    """Unified bulk update: set status and/or processor in one transaction.
+
+    Accepts JSON: {return_ids: [1,2,3], status: "PICKUP", processor: "Alice"}
+    At least one of status or processor must be supplied.
+    Maximum BULK_RETURN_IDS_CAP IDs per request.
+    Each changed return is audited individually.
+    Never returns ssn or identification fields.
+    """
+    payload     = _get_json_safe() or {}
+    raw_ids     = payload.get("return_ids")
+    new_status  = (payload.get("status") or "").strip().upper() or None
+    processor   = payload.get("processor")  # may be None to leave unchanged
+
+    if not isinstance(raw_ids, list) or not raw_ids:
+        return jsonify({"error": "return_ids required (non-empty list)"}), 400
+    if len(raw_ids) > BULK_RETURN_IDS_CAP:
+        return jsonify({"error": f"Too many returns (max {BULK_RETURN_IDS_CAP})"}), 400
+    try:
+        parsed_ids = [int(x) for x in raw_ids]
+    except (TypeError, ValueError):
+        return jsonify({"error": "return_ids must be integers"}), 400
+
+    if new_status is None and processor is None:
+        return jsonify({"error": "At least one of status or processor must be provided"}), 400
+    if new_status is not None and new_status not in STATUS_FLOW:
+        return jsonify({"error": f"Invalid status. Allowed: {STATUS_FLOW}"}), 400
+
+    actor = (session.get("username") or "").strip() or "?"
+    conn  = get_connection()
+    try:
+        conn.execute("BEGIN")
+        errors: list[str] = []
+        updated_count = 0
+
+        if new_status is not None:
+            errs = bulk_apply_status_changes(
+                conn,
+                return_ids=parsed_ids,
+                new_status=new_status,
+                status_flow=tuple(STATUS_FLOW),
+                status_date_stamp=STATUS_DATE_STAMP,
+                actor_username=actor,
+            )
+            if errs:
+                conn.rollback()
+                return jsonify({"success": False, "errors": errs, "updated_count": 0}), 409
+            updated_count = len(parsed_ids)
+
+        if processor is not None:
+            perrs, rows_updated = bulk_apply_processor_changes(
+                conn,
+                return_ids=parsed_ids,
+                new_processor_raw=processor,
+                actor_username=actor,
+            )
+            if perrs:
+                conn.rollback()
+                return jsonify({"success": False, "errors": perrs, "updated_count": 0}), 409
+            updated_count = max(updated_count, rows_updated)
+
+        conn.commit()
+        return jsonify({"success": True, "updated_count": updated_count})
+    finally:
+        conn.close()
+
+
 def _validate_field(field: str, value) -> tuple[bool, str]:
     """REL-6: coerce and validate a value for a known editable field.
 
@@ -4274,6 +4608,411 @@ def api_missing_doc_delete(return_id: int, doc_id: int):
     conn.commit()
     conn.close()
     return jsonify({"success": True})
+
+
+# ── DEP-1: Remove dependent from return ──────────────────────────────────────
+
+@app.delete("/api/return/<int:return_id>/dependents/<int:dep_id>")
+@login_required
+def api_dependent_delete(return_id: int, dep_id: int):
+    user   = session.get("username")
+    ip     = request.remote_addr
+    ts     = now()
+    conn   = get_connection()
+    try:
+        row = conn.execute(
+            "SELECT id, full_name FROM dependents WHERE id=? AND return_id=? AND is_deleted=0",
+            (dep_id, return_id),
+        ).fetchone()
+        if not row:
+            return jsonify({"error": "Dependent not found"}), 404
+        before = dict(row)
+        conn.execute(
+            "UPDATE dependents SET is_deleted=1 WHERE id=? AND return_id=?",
+            (dep_id, return_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    from audit_service import _enqueue_write
+    _enqueue_write(
+        user_id=user,
+        action="DEPENDENT_REMOVED",
+        entity_type="dependent",
+        entity_id=str(dep_id),
+        before=before,
+        after={"is_deleted": 1, "return_id": return_id},
+        ip_address=ip,
+        http_status=200,
+    )
+    return jsonify({"success": True})
+
+
+# ── LIFE-1: Cancel / uncancel return ─────────────────────────────────────────
+
+@app.post("/api/return/<int:return_id>/cancel")
+@login_required
+def api_cancel_return(return_id: int):
+    data   = _get_json_safe()
+    reason = (data.get("reason") or "").strip()
+    if not reason:
+        return jsonify({"error": "reason is required"}), 400
+    user = session.get("username")
+    ip   = request.remote_addr
+    ts   = now()
+    conn = get_connection()
+    try:
+        ret = conn.execute("SELECT client_status FROM returns WHERE id=?", (return_id,)).fetchone()
+        if not ret:
+            return jsonify({"error": "Return not found"}), 404
+        if (ret["client_status"] or "").upper() == "CANCELLED":
+            return jsonify({"error": "Already cancelled"}), 409
+        pmt = conn.execute(
+            "SELECT id, total_fee, fee_paid FROM payments WHERE return_id=?", (return_id,)
+        ).fetchone()
+        original_fee = float(pmt["total_fee"] or 0) if pmt else 0.0
+        if pmt:
+            conn.execute(
+                "UPDATE payments SET cancelled_fee=?, total_fee=0, fee_paid=0 WHERE return_id=?",
+                (original_fee, return_id),
+            )
+        conn.execute(
+            "UPDATE returns SET client_status='CANCELLED', cancelled_fee=?, "
+            "cancelled_reason=?, cancelled_at=?, updated_at=? WHERE id=?",
+            (original_fee, reason, ts, ts, return_id),
+        )
+        note_text = f"Return cancelled: {reason} — original fee was ${original_fee:,.2f}"
+        conn.execute(
+            "INSERT INTO notes (return_id, note_text, source, created_at) VALUES (?,?,'CANCEL',?)",
+            (return_id, note_text, ts),
+        )
+        conn.execute(
+            "INSERT INTO status_events (return_id, event_type, old_status, new_status, "
+            "event_timestamp, source_file, note) VALUES (?, 'STATUS_CHANGED', ?, 'CANCELLED', ?, 'APP', ?)",
+            (return_id, ret["client_status"], ts, reason),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    from audit_service import _enqueue_write
+    _enqueue_write(
+        user_id=user, action="RETURN_CANCELLED", entity_type="return",
+        entity_id=str(return_id), before={"client_status": ret["client_status"], "total_fee": original_fee},
+        after={"client_status": "CANCELLED", "total_fee": 0, "reason": reason},
+        ip_address=ip, http_status=200,
+    )
+    return jsonify({"success": True, "original_fee": original_fee})
+
+
+@app.post("/api/return/<int:return_id>/uncancel")
+@login_required
+def api_uncancel_return(return_id: int):
+    user = session.get("username")
+    ip   = request.remote_addr
+    ts   = now()
+    conn = get_connection()
+    try:
+        ret = conn.execute(
+            "SELECT client_status, cancelled_fee FROM returns WHERE id=?", (return_id,)
+        ).fetchone()
+        if not ret:
+            return jsonify({"error": "Return not found"}), 404
+        if (ret["client_status"] or "").upper() != "CANCELLED":
+            return jsonify({"error": "Return is not cancelled"}), 409
+        restored_fee = ret["cancelled_fee"] or 0.0
+        conn.execute(
+            "UPDATE returns SET client_status='PROCESSING', cancelled_fee=NULL, "
+            "cancelled_reason=NULL, cancelled_at=NULL, updated_at=? WHERE id=?",
+            (ts, return_id),
+        )
+        conn.execute(
+            "UPDATE payments SET total_fee=?, cancelled_fee=NULL WHERE return_id=?",
+            (restored_fee, return_id),
+        )
+        conn.execute(
+            "INSERT INTO notes (return_id, note_text, source, created_at) VALUES (?,?,'UNCANCEL',?)",
+            (return_id, f"Cancellation reversed — fee restored to ${restored_fee:,.2f}", ts),
+        )
+        conn.execute(
+            "INSERT INTO status_events (return_id, event_type, old_status, new_status, "
+            "event_timestamp, source_file, note) VALUES (?, 'STATUS_CHANGED', 'CANCELLED', 'PROCESSING', ?, 'APP', ?)",
+            (return_id, ts, "Cancellation reversed"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    from audit_service import _enqueue_write
+    _enqueue_write(
+        user_id=user, action="RETURN_UNCANCELLED", entity_type="return",
+        entity_id=str(return_id), before={"client_status": "CANCELLED"},
+        after={"client_status": "PROCESSING", "total_fee": restored_fee},
+        ip_address=ip, http_status=200,
+    )
+    return jsonify({"success": True, "restored_fee": restored_fee})
+
+
+# ── BANK-1: Routing number lookup (local JSON only) ───────────────────────────
+
+import json as _json_mod
+
+_ROUTING_DB: dict[str, str] | None = None
+
+def _load_routing_db() -> dict[str, str]:
+    global _ROUTING_DB
+    if _ROUTING_DB is None:
+        path = os.path.join(os.path.dirname(__file__), "data", "routing_numbers.json")
+        try:
+            with open(path, encoding="utf-8") as f:
+                _ROUTING_DB = _json_mod.load(f)
+        except Exception:
+            _ROUTING_DB = {}
+    return _ROUTING_DB
+
+
+@app.get("/api/routing-number/<string:routing_number>")
+@login_required
+def api_routing_number(routing_number: str):
+    if not routing_number.isdigit() or len(routing_number) != 9:
+        return jsonify({"error": "Routing number must be exactly 9 digits"}), 400
+    db = _load_routing_db()
+    bank_name = db.get(routing_number)
+    if bank_name:
+        return jsonify({"found": True, "bank_name": bank_name})
+    return jsonify({"found": False})
+
+
+# ── LIFE-2: Prior year fee for returning client intake ────────────────────────
+
+@app.get("/api/clients/<int:client_id>/prior-fee")
+@login_required
+def api_client_prior_fee(client_id: int):
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            """
+            SELECT r.tax_year, p.total_fee
+            FROM returns r
+            LEFT JOIN payments p ON p.return_id = r.id
+            WHERE r.client_id = ?
+              AND r.tax_year = (
+                  SELECT MAX(tax_year) FROM returns
+                  WHERE client_id = ? AND UPPER(COALESCE(client_status,'')) != 'CANCELLED'
+              )
+              AND UPPER(COALESCE(r.client_status, '')) != 'CANCELLED'
+            LIMIT 1
+            """,
+            (client_id, client_id),
+        ).fetchone()
+    finally:
+        conn.close()
+    if not row or row["total_fee"] is None:
+        return jsonify({"found": False})
+    return jsonify({
+        "found": True,
+        "tax_year": row["tax_year"],
+        "total_fee": float(row["total_fee"]),
+    })
+
+
+# ── LIFE-3: Intake sheet PDF ──────────────────────────────────────────────────
+
+@app.get("/api/return/<int:return_id>/intake-sheet")
+@login_required
+def api_intake_sheet(return_id: int):
+    from reportlab.lib.pagesizes import letter
+    from reportlab.lib.units import inch
+    from reportlab.lib import colors
+    from reportlab.platypus import (
+        SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle, HRFlowable,
+    )
+    from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+    import io as _io
+
+    conn = get_connection()
+    try:
+        ret = conn.execute(
+            """
+            SELECT r.*, c.last_name, c.first_name, c.display_name,
+                   c.taxpayer_phone, c.taxpayer_cell, c.address,
+                   c.ssn_last4, c.taxpayer_email, c.spouse_last_name, c.spouse_first_name
+            FROM returns r JOIN clients c ON c.id = r.client_id
+            WHERE r.id = ?
+            """,
+            (return_id,),
+        ).fetchone()
+        if not ret:
+            conn.close()
+            return jsonify({"error": "Return not found"}), 404
+        r = dict(ret)
+
+        pmt = conn.execute(
+            "SELECT total_fee, discount_amount, special_discount FROM payments WHERE return_id=?",
+            (return_id,),
+        ).fetchone()
+
+        deps = conn.execute(
+            """
+            SELECT full_name, ssn_last4, relationship, date_of_birth, on_medicare
+            FROM dependents WHERE return_id=? AND is_deleted=0 ORDER BY id
+            """,
+            (return_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    # Privacy: mask SSN (always last4 only) and account number
+    acct_raw   = (r.get("bank_account") or "")
+    acct_masked = ("*" * (len(acct_raw) - 4) + acct_raw[-4:]) if len(acct_raw) > 4 else acct_raw
+
+    buf    = _io.BytesIO()
+    doc    = SimpleDocTemplate(buf, pagesize=letter, topMargin=0.75*inch, bottomMargin=0.75*inch,
+                                leftMargin=0.75*inch, rightMargin=0.75*inch)
+    styles = getSampleStyleSheet()
+    h1     = styles["Heading1"]
+    h2     = ParagraphStyle("h2", parent=styles["Heading2"], spaceAfter=4)
+    body   = styles["Normal"]
+    muted  = ParagraphStyle("muted", parent=styles["Normal"], textColor=colors.grey, fontSize=8)
+
+    client_name = (
+        r.get("display_name")
+        or f"{r.get('last_name','')}, {r.get('first_name','')}".strip(", ")
+    )
+    spouse_name = ""
+    if r.get("spouse_last_name") or r.get("spouse_first_name"):
+        spouse_name = f"{r.get('spouse_last_name','')}, {r.get('spouse_first_name','')}".strip(", ")
+
+    preparer_label = preparer_list_label(r.get("processor") or "")
+
+    elems = []
+    # Office header
+    elems.append(Paragraph("Xcel Financial Services, LLC", h1))
+    elems.append(Paragraph("Income Tax Client Intake Sheet", styles["Heading2"]))
+    elems.append(HRFlowable(width="100%", thickness=1, color=colors.black))
+    elems.append(Spacer(1, 0.1*inch))
+
+    # Return meta
+    meta_data = [
+        ["Tax Year:", str(r.get("tax_year") or ""), "Log #:", str(r.get("log_number") or "")],
+        ["Intake Date:", str(r.get("intake_date") or ""), "Preparer:", preparer_label],
+        ["Filing Status:", str(r.get("filing_status") or ""), "Return ID:", str(return_id)],
+    ]
+    meta_tbl = Table(meta_data, colWidths=[1.2*inch, 2.3*inch, 1.2*inch, 2.3*inch])
+    meta_tbl.setStyle(TableStyle([
+        ("FONTNAME", (0,0), (-1,-1), "Helvetica"),
+        ("FONTSIZE", (0,0), (-1,-1), 9),
+        ("FONTNAME", (0,0), (0,-1), "Helvetica-Bold"),
+        ("FONTNAME", (2,0), (2,-1), "Helvetica-Bold"),
+        ("TOPPADDING", (0,0), (-1,-1), 3),
+        ("BOTTOMPADDING", (0,0), (-1,-1), 3),
+    ]))
+    elems.append(meta_tbl)
+    elems.append(Spacer(1, 0.1*inch))
+
+    # Client info
+    elems.append(Paragraph("Client Information", h2))
+    ci_data = [
+        ["Taxpayer:", client_name, "SSN Last 4:", str(r.get("ssn_last4") or "")],
+        ["Spouse:", spouse_name, "", ""],
+        ["Address:", str(r.get("address") or ""), "", ""],
+        ["Cell:", str(r.get("taxpayer_cell") or ""), "Home:", str(r.get("taxpayer_phone") or "")],
+        ["Email:", str(r.get("taxpayer_email") or ""), "", ""],
+    ]
+    ci_tbl = Table(ci_data, colWidths=[1.2*inch, 2.3*inch, 1.2*inch, 2.3*inch])
+    ci_tbl.setStyle(TableStyle([
+        ("FONTNAME", (0,0), (-1,-1), "Helvetica"),
+        ("FONTSIZE", (0,0), (-1,-1), 9),
+        ("FONTNAME", (0,0), (0,-1), "Helvetica-Bold"),
+        ("FONTNAME", (2,0), (2,-1), "Helvetica-Bold"),
+        ("TOPPADDING", (0,0), (-1,-1), 3),
+        ("BOTTOMPADDING", (0,0), (-1,-1), 3),
+    ]))
+    elems.append(ci_tbl)
+    elems.append(Spacer(1, 0.1*inch))
+
+    # Dependents
+    if deps:
+        elems.append(Paragraph("Dependents", h2))
+        dep_header = [["Name", "DOB", "Relationship", "SSN Last 4", "Medicare"]]
+        dep_rows = dep_header + [
+            [
+                str(d["full_name"] or ""),
+                str(d["date_of_birth"] or ""),
+                str(d["relationship"] or ""),
+                str(d["ssn_last4"] or ""),
+                "Yes" if d["on_medicare"] else "No",
+            ]
+            for d in deps
+        ]
+        dep_tbl = Table(dep_rows, colWidths=[2*inch, 1*inch, 1.8*inch, 0.9*inch, 0.8*inch])
+        dep_tbl.setStyle(TableStyle([
+            ("BACKGROUND", (0,0), (-1,0), colors.HexColor("#334155")),
+            ("TEXTCOLOR", (0,0), (-1,0), colors.white),
+            ("FONTNAME", (0,0), (-1,0), "Helvetica-Bold"),
+            ("FONTNAME", (0,1), (-1,-1), "Helvetica"),
+            ("FONTSIZE", (0,0), (-1,-1), 8),
+            ("TOPPADDING", (0,0), (-1,-1), 3),
+            ("BOTTOMPADDING", (0,0), (-1,-1), 3),
+            ("ROWBACKGROUNDS", (0,1), (-1,-1), [colors.white, colors.HexColor("#f8fafc")]),
+            ("GRID", (0,0), (-1,-1), 0.5, colors.HexColor("#cbd5e1")),
+        ]))
+        elems.append(dep_tbl)
+        elems.append(Spacer(1, 0.1*inch))
+
+    # Banking
+    elems.append(Paragraph("Banking Information", h2))
+    bk_data = [
+        ["Bank Name:", str(r.get("bank_name") or ""), "Account Type:", str(r.get("bank_account_type") or "")],
+        ["Routing #:", str(r.get("bank_routing") or ""), "Account # (last 4):", acct_masked],
+    ]
+    bk_tbl = Table(bk_data, colWidths=[1.2*inch, 2.3*inch, 1.5*inch, 2.0*inch])
+    bk_tbl.setStyle(TableStyle([
+        ("FONTNAME", (0,0), (-1,-1), "Helvetica"),
+        ("FONTSIZE", (0,0), (-1,-1), 9),
+        ("FONTNAME", (0,0), (0,-1), "Helvetica-Bold"),
+        ("FONTNAME", (2,0), (2,-1), "Helvetica-Bold"),
+        ("TOPPADDING", (0,0), (-1,-1), 3),
+        ("BOTTOMPADDING", (0,0), (-1,-1), 3),
+    ]))
+    elems.append(bk_tbl)
+    elems.append(Spacer(1, 0.1*inch))
+
+    # Fees
+    elems.append(Paragraph("Fees", h2))
+    total_fee = float(pmt["total_fee"] or 0) if pmt else 0.0
+    discount  = float(pmt["discount_amount"] or 0) if pmt else 0.0
+    sp_disc   = float(pmt["special_discount"] or 0) if pmt else 0.0
+    fee_data  = [
+        ["Total Fee:", f"${total_fee:,.2f}"],
+        ["Discount:", f"-${discount + sp_disc:,.2f}"],
+        ["Net Fee:", f"${max(0, total_fee - discount - sp_disc):,.2f}"],
+    ]
+    fee_tbl = Table(fee_data, colWidths=[1.5*inch, 1.5*inch])
+    fee_tbl.setStyle(TableStyle([
+        ("FONTNAME", (0,0), (-1,-1), "Helvetica"),
+        ("FONTSIZE", (0,0), (-1,-1), 9),
+        ("FONTNAME", (0,0), (0,-1), "Helvetica-Bold"),
+        ("TOPPADDING", (0,0), (-1,-1), 3),
+        ("BOTTOMPADDING", (0,0), (-1,-1), 3),
+    ]))
+    elems.append(fee_tbl)
+    elems.append(Spacer(1, 0.15*inch))
+
+    # Signature line
+    elems.append(HRFlowable(width="100%", thickness=0.5, color=colors.grey))
+    elems.append(Spacer(1, 0.1*inch))
+    elems.append(Paragraph("Client signature: _______________________________   Date: _______________", body))
+    elems.append(Spacer(1, 0.05*inch))
+    elems.append(Paragraph("SSN not shown on this sheet for privacy protection.", muted))
+
+    doc.build(elems)
+    buf.seek(0)
+    return Response(
+        buf.read(),
+        mimetype="application/pdf",
+        headers={
+            "Content-Disposition": f'attachment; filename="intake_{return_id}.pdf"',
+        },
+    )
 
 
 # ── Duplicate client detection & merge ───────────────────────────────────────
@@ -5585,6 +6324,155 @@ def register_workers(flask_app) -> None:
             _log.warning("Chat cache warmup skipped: %s", ex)
 
     threading.Thread(target=_warm_chat_cache, daemon=True, name="chat-cache-warm").start()
+
+
+@app.post("/api/admin/reset-and-reimport")
+@login_required
+def api_admin_reset_and_reimport():
+    """
+    Controlled DB deduplication + forced re-import of every CSV in data/incoming/.
+
+    Requirements:
+      - Admin role only
+      - Exact confirmation string "RESET AND REIMPORT" in request body
+      - Creates a timestamped DB backup before touching anything
+      - Runs _deduplicate_existing_records
+      - Re-runs every CSV through the upsert importer (no new files moved; upsert is safe)
+      - Audit-logs the action
+    """
+    if _resolve_current_role() != "admin":
+        return jsonify({"error": "Forbidden — admin only"}), 403
+
+    data = _get_json_safe() or {}
+    if data.get("confirm") != "RESET AND REIMPORT":
+        return jsonify({"error": "Confirmation required: send {\"confirm\": \"RESET AND REIMPORT\"}"}), 400
+
+    import shutil as _shutil
+    from datetime import datetime as _dt
+    from pathlib import Path as _Path
+    from db import _deduplicate_existing_records
+    import main as _main_mod
+    from config import INCOMING_DIR, DB_PATH as _DB_PATH
+
+    actor = _session_username() or "unknown"
+
+    # 1. Timestamped backup
+    backup_path = _DB_PATH + ".backup." + _dt.now().strftime("%Y%m%d_%H%M%S")
+    try:
+        _shutil.copy2(_DB_PATH, backup_path)
+        current_app.logger.info("reset-and-reimport: DB backup created: %s", backup_path)
+    except Exception as exc:
+        return jsonify({"error": f"Backup failed: {exc}"}), 500
+
+    result_summary: dict = {
+        "backup_file": backup_path,
+        "dedup_removed": 0,
+        "files_processed": [],
+        "totals": {
+            "clients_created": 0,
+            "clients_updated": 0,
+            "returns_created": 0,
+            "returns_updated": 0,
+            "rows_skipped": 0,
+            "errors": [],
+        },
+    }
+
+    conn = get_connection()
+    try:
+        # 2. Dedup existing records
+        conn.execute("BEGIN")
+        removed = _deduplicate_existing_records(conn)
+        conn.commit()
+        result_summary["dedup_removed"] = removed
+
+        # 3. Re-run every CSV in data/incoming/
+        from utils import ImportResult
+        from datetime import date as _date
+
+        for csv_file in sorted(_Path(INCOMING_DIR).glob("*.csv")):
+            from main import _drake_year as _dy
+            from drake_importer import process_drake_csv, _open_and_detect
+            from importer import process_csv
+
+            try:
+                from utils import hash_file
+                file_hash = hash_file(str(csv_file))
+                batch_id = _main_mod.create_batch(conn, csv_file.name, file_hash + "_reimport_" + actor)
+            except Exception:
+                batch_id = _main_mod.create_batch(conn, csv_file.name, str(csv_file.stat().st_mtime))
+
+            stats: ImportResult | None = None
+            try:
+                conn.execute("BEGIN")
+                drake_year = _dy(csv_file.name)
+                if drake_year is not None:
+                    stats = process_drake_csv(conn, str(csv_file), batch_id, csv_file.name, drake_year)
+                else:
+                    # Try Drake CSM detection first; fall back to manual-log importer
+                    _, fmt = _open_and_detect(str(csv_file))
+                    if fmt != "UNKNOWN":
+                        # CSM or TAX_OPS format — use current year - 1 as tax year
+                        ty = _date.today().year - 1
+                        stats = process_drake_csv(conn, str(csv_file), batch_id, csv_file.name, ty)
+                    else:
+                        stats = process_csv(conn, str(csv_file), batch_id, csv_file.name)
+                conn.commit()
+            except Exception as exc:
+                conn.rollback()
+                current_app.logger.exception("reset-and-reimport: error processing %s", csv_file.name)
+                result_summary["files_processed"].append({
+                    "filename": csv_file.name,
+                    "error": str(exc),
+                })
+                result_summary["totals"]["errors"].append(f"{csv_file.name}: {exc}")
+                continue
+
+            if stats:
+                result_summary["files_processed"].append({
+                    "filename":        csv_file.name,
+                    "source":          stats.source,
+                    "rows":            stats.row_count,
+                    "clients_created": stats.created_clients,
+                    "clients_updated": stats.updated_clients,
+                    "returns_created": stats.created_returns,
+                    "returns_updated": stats.updated_returns,
+                    "errors":          stats.errors,
+                    "duration_s":      round(stats.duration_seconds, 2),
+                })
+                t = result_summary["totals"]
+                t["clients_created"] += stats.created_clients
+                t["clients_updated"] += stats.updated_clients
+                t["returns_created"] += stats.created_returns
+                t["returns_updated"] += stats.updated_returns
+                t["errors"].extend(stats.errors)
+
+        # 4. Audit the action
+        try:
+            from audit_service import _enqueue_write
+            _enqueue_write(
+                user_id=actor,
+                action="ADMIN_RESET_AND_REIMPORT",
+                entity_type="system",
+                entity_id=None,
+                before_data=None,
+                after_data=result_summary,
+            )
+        except Exception:
+            pass
+
+    finally:
+        conn.close()
+
+    current_app.logger.info(
+        "reset-and-reimport by %s: dedup_removed=%s files=%s clients_created=%s returns_created=%s",
+        actor,
+        result_summary["dedup_removed"],
+        len(result_summary["files_processed"]),
+        result_summary["totals"]["clients_created"],
+        result_summary["totals"]["returns_created"],
+    )
+    return jsonify({"success": True, **result_summary}), 200
 
 
 if __name__ == "__main__":

--- a/taxops/config.py
+++ b/taxops/config.py
@@ -281,10 +281,35 @@ IMAP_USER          = os.environ.get("IMAP_USER", "")
 IMAP_PASS          = os.environ.get("IMAP_PASS", "")
 IMAP_POLL_INTERVAL = int(os.environ.get("IMAP_POLL_INTERVAL", 120))
 IMAP_FOLDER        = os.environ.get("IMAP_FOLDER", "INBOX")
-# Set to true to log what would be marked as read without touching Gmail
+
+# Comma-separated list of folders to poll when USE_GMAIL_CATEGORIES is false.
+# Folder names with spaces are supported (e.g. "TAX DOCUMENTS FROM CLIENTS").
+IMAP_FOLDERS: list[str] = [
+    f.strip()
+    for f in os.environ.get("IMAP_FOLDERS", IMAP_FOLDER).split(",")
+    if f.strip()
+]
+
+# Domain(s) the office sends from — emails arriving from these are self-sent.
+# Auto-derived from IMAP_USER; extend with OWN_EMAIL_DOMAINS env var (comma-separated).
+_imap_own_domain   = IMAP_USER.split("@")[-1].lower() if "@" in IMAP_USER else ""
+_extra_own         = os.environ.get("OWN_EMAIL_DOMAINS", "")
+OWN_EMAIL_DOMAINS: frozenset = frozenset(
+    d.strip().lower()
+    for d in ([_imap_own_domain] + _extra_own.split(","))
+    if d.strip()
+)
+# Dry-run: log what the mail watcher would do without touching any IMAP state.
 IMAP_DRY_RUN: bool = os.environ.get("IMAP_DRY_RUN", "false").lower() == "true"
-# When false, mail watcher never adds \\Seen — emails stay unread in the mailbox (still processes).
+# POLICY: TaxOps never sets or clears \Seen on any message.  IMAP_MARK_AS_READ
+# and IMAP_PRESERVE_UNREAD are retained for config-file backward compatibility
+# but have no effect — _mark_read() is never called anywhere in the codebase.
 IMAP_MARK_AS_READ: bool = os.environ.get("IMAP_MARK_AS_READ", "true").lower() == "true"
+# Part 5: max consecutive retry attempts before an email is permanently skipped.
+IMAP_MAX_RETRIES: int = int(os.environ.get("IMAP_MAX_RETRIES", "3"))
+# Retained for backward compat — no longer gates any behavior.  DB log dedup
+# (email_processing_log) runs unconditionally on every poll.
+IMAP_PRESERVE_UNREAD: bool = os.environ.get("IMAP_PRESERVE_UNREAD", "false").lower() == "true"
 
 # Ollama HTTP timeout for mail-watcher LLM calls (name extraction, domain classify)
 MAIL_WATCHER_LLM_TIMEOUT = int(os.environ.get("MAIL_WATCHER_LLM_TIMEOUT", "45"))
@@ -292,6 +317,11 @@ MAIL_WATCHER_LLM_TIMEOUT = int(os.environ.get("MAIL_WATCHER_LLM_TIMEOUT", "45"))
 # Fuzzy client match minimum for routing email attachments (name_matcher ACCEPT_THRESHOLD is 88).
 # Lower values attach more aggressively — verify Office tolerance before lowering below ~80.
 MAIL_WATCHER_CLIENT_MATCH_MIN_SCORE = int(os.environ.get("MAIL_WATCHER_CLIENT_MATCH_MIN_SCORE", "82"))
+
+# When false (default): image files (.jpg, .jpeg, .png) skip the vision model entirely.
+# Images are saved to the return and staff tag them manually.
+# Set true only when Ollama has enough resources for concurrent vision requests.
+EXTRACTOR_VISION_ENABLED: bool = os.environ.get("EXTRACTOR_VISION_ENABLED", "false").lower() == "true"
 
 # EMAIL-7: matches with score >= MIN_SCORE but < LOW_CONF_THRESHOLD go to pending_review
 # instead of auto-attaching; staff confirms/rejects from Email Review → Pending Review.
@@ -425,6 +455,38 @@ PERSONAL_EMAIL_DOMAINS: frozenset = frozenset({
     "xcelfinancial.com",
 })
 
+# Client business domains — unique domains that belong to real clients and will
+# never appear in a generic spam training set.  Emails from these domains bypass
+# the ML classifier entirely and go straight to LLM evaluation.  After the first
+# successful attachment save, the domain is auto-boosted to cache so subsequent
+# emails hit the cache layer (Layer 5) and skip both ML and LLM.
+#
+# Populated via IMAP_CLIENT_HINT_DOMAINS env var (comma-separated).
+# Example: IMAP_CLIENT_HINT_DOMAINS=olavictory.org,coronabrosinstall.com,orealtyllc.com
+CLIENT_HINT_DOMAINS: frozenset = frozenset(
+    d.strip().lower()
+    for d in os.environ.get("IMAP_CLIENT_HINT_DOMAINS", "").split(",")
+    if d.strip()
+)
+
+# Asymmetric classifier confidence thresholds.
+# The penalty for a false-promotional classification (silently dropping a client
+# email) is much worse than a false-client classification (staff reviews an extra
+# email).  Promotional therefore requires higher confidence before being accepted.
+# Below either threshold the result is discarded and the email falls through to LLM.
+CLASSIFIER_PROMOTIONAL_THRESHOLD: float = float(
+    os.environ.get("CLASSIFIER_PROMOTIONAL_THRESHOLD", "0.80")
+)
+CLASSIFIER_CLIENT_THRESHOLD: float = float(
+    os.environ.get("CLASSIFIER_CLIENT_THRESHOLD", "0.65")
+)
+
+# ── INTAKE-8: Auto-discount for new client intakes ───────────────────────────
+# Dollar amount automatically applied as discount_amount on every new intake.
+# Set to 0 to disable. Configurable without a code change.
+INTAKE_AUTO_DISCOUNT: int = int(os.environ.get("INTAKE_AUTO_DISCOUNT", "20"))
+INTAKE_SUGGESTED_UPCHARGE_PCT: int = int(os.environ.get("INTAKE_SUGGESTED_UPCHARGE_PCT", "8"))
+
 # ── ACCOUNTING-2: Receipt OCR → QuickBooks categorization ────────────────────
 # Ollama vision model for receipt OCR (defaults to the existing extraction vision model).
 ACCOUNTING_VISION_MODEL: str = (
@@ -471,6 +533,11 @@ DRAKE_STATUS_MAP: dict[str, str] = {
     "EXTENSION":                    "PROCESSING",
     "EF REJECTED":                  "PROCESSING",
     "EF REJECT":                    "PROCESSING",
+    "EF PENDING":                   "PROCESSING",
+    # Prior-year carryforward — data rolled from prior season, needs work
+    "UPDATED FROM 2024":            "PROCESSING",
+    "UPDATED FROM 2023":            "PROCESSING",
+    "UPDATED FROM 2022":            "PROCESSING",
     # Drake "ready/printed" — prep done, client needs to sign before efiling
     "READY TO FILE":                "PICKUP",
     "READY TO PRINT":               "PICKUP",

--- a/taxops/mail_watcher.py
+++ b/taxops/mail_watcher.py
@@ -47,6 +47,24 @@ _processed_uids: OrderedDict[tuple[str, str], None] = OrderedDict()
 # Serializes memo checks / claims so concurrent callers cannot duplicate-claim one UID.
 _processed_uids_lock = threading.Lock()
 
+# ── Processing outcome constants ──────────────────────────────────────────────
+# Every message processing path returns exactly one of these.
+# The mark-as-read decision is made ONLY at one location in _poll_once_inner,
+# never inline.
+#
+# READ-STATUS POLICY (absolute — no exceptions):
+#   1. BODY.PEEK[] is used for all FETCH calls so the IMAP server never
+#      auto-sets \\Seen as a side-effect of downloading the message body.
+#   2. _mark_read is NEVER called — read/unread state is never modified.
+#   3. email_processing_log is the restart-safe dedup layer (checked every
+#      poll regardless of any config flag).
+#   4. OUTCOME_RETRY leaves the message unread so the next poll retries it.
+#   5. OUTCOME_DRY_RUN never touches IMAP state.
+OUTCOME_SUCCESS = "success"   # fully processed (terminal)
+OUTCOME_SKIP    = "skip"      # intentionally skipped — promo, known rule, no match (terminal)
+OUTCOME_RETRY   = "retry"     # transient failure — leave unread for next poll cycle
+OUTCOME_DRY_RUN = "dry_run"   # dry-run mode — no IMAP state changes
+
 
 def _mark_uid_processed(folder: str, uid: str) -> bool:
     """DEBT-7: claim a (folder, uid) pair; return True if newly claimed, False if already seen.
@@ -125,8 +143,8 @@ def _poll_once(app) -> None:
     One full poll cycle:
     1. Connect + login (credentials never logged)
     2. Select folder
-    3. Search UNSEEN
-    4. Process each message — mark READ regardless of success
+    3. Search UNSEEN — fetch with BODY.PEEK[] so \\Seen is never auto-set
+    4. Process each message — read/unread state is NEVER modified
     5. Logout
 
     Skips entirely if a previous cycle is still running (LLM calls can be slow).
@@ -189,9 +207,14 @@ def _safe_select(imap, folder: str) -> bool:
     Safely select an IMAP folder.
     Returns True if selected OK, False if folder does not exist or errors.
     Never raises.
+
+    Folder names containing spaces must be double-quoted per RFC 3501.
+    imaplib does not add quotes automatically, so we add them here when needed.
     """
     try:
-        resp = imap.select(folder)
+        # RFC 3501: mailbox names with special characters / spaces must be quoted.
+        imap_folder = f'"{folder}"' if " " in folder and not folder.startswith('"') else folder
+        resp = imap.select(imap_folder)
         if not isinstance(resp, tuple) or len(resp) < 2:
             logger.info(f"Folder {folder!r} not selectable — malformed response: {resp!r}")
             return False
@@ -206,24 +229,19 @@ def _safe_select(imap, folder: str) -> bool:
         return False
 
 
-def _mark_read(imap, uid, reason: str) -> None:
+def _mark_read(imap, uid, reason: str) -> None:  # noqa: ARG001
     """
-    Mark a message as read via UID STORE.
-    Respects IMAP_MARK_AS_READ — when False, leaves messages unread (still processed).
-    Respects IMAP_DRY_RUN — logs only, does not touch Gmail when enabled.
-    Never raises.
+    DISABLED — TaxOps never modifies the read/unread state of any email.
+
+    Read-status policy (enforced at three layers):
+      1. BODY.PEEK[] fetch — IMAP server never auto-sets \\Seen on download.
+      2. This function is never called from anywhere in the codebase.
+      3. No -FLAGS \\Seen STORE call exists anywhere.
+
+    Kept as a tombstone so git history explains why it was removed and so a
+    future developer cannot accidentally re-introduce the call without seeing
+    this comment.
     """
-    from config import IMAP_DRY_RUN, IMAP_MARK_AS_READ
-    if not IMAP_MARK_AS_READ:
-        return
-    if IMAP_DRY_RUN:
-        logger.info(f"DRY RUN — would mark read: uid={uid!r} reason={reason}")
-        return
-    try:
-        imap.uid("STORE", uid, "+FLAGS", "\\Seen")
-        logger.debug(f"Marked read: uid={uid!r} reason={reason}")
-    except Exception as e:
-        logger.error(f"Failed to mark read uid={uid!r}: {e}")
 
 
 def _fetch_message_data(imap, uid) -> dict | None:
@@ -233,7 +251,10 @@ def _fetch_message_data(imap, uid) -> dict | None:
     or None if the message cannot be fetched.
     Body text is extracted here for LLM use — never stored beyond this function.
     """
-    resp = imap.uid("FETCH", uid, "(RFC822)")
+    # BODY.PEEK[] is identical to RFC822 but never sets \Seen on the server.
+    # Gmail (and any RFC-2060 server) marks a message as read the moment you
+    # fetch it with RFC822; PEEK suppresses that side-effect entirely.
+    resp = imap.uid("FETCH", uid, "(BODY.PEEK[])")
     if not isinstance(resp, tuple) or len(resp) < 2:
         logger.error(f"Unexpected IMAP UID FETCH response for uid={uid!r}: {resp!r}")
         return None
@@ -267,30 +288,31 @@ def _fetch_message_data(imap, uid) -> dict | None:
     }
 
 
-def _dispatch_classified_message(app, msg: dict) -> None:
+def _dispatch_classified_message(app, msg: dict) -> str:
     """Execute the appropriate action for a message whose classification is known.
 
-    Handles: hard-skip, promotional, unknown, client_document/inquiry.
-    source_layer controls whether the result is recorded in email_classifications.
+    Returns one of the OUTCOME_* constants.  This function never touches IMAP
+    state.  The caller (_poll_once_inner) logs the outcome but also never
+    modifies read/unread status — see READ-STATUS POLICY in _poll_once_inner.
 
-    Does NOT touch IMAP state — Gmail read/unread is left unchanged.
+    Outcome semantics:
+      OUTCOME_SUCCESS — new documents or note saved; email left unread.
+      OUTCOME_SKIP    — intentionally skipped (promo, known rule, no client
+                        match, or all-duplicate attachments); email left unread.
+      OUTCOME_RETRY   — processing failed; email left unread for next poll.
 
     EMAIL-1 — UID deduplication contract
     ─────────────────────────────────────
     Every caller MUST claim the UID via ``_mark_uid_processed()`` *before* calling
     this function (done in ``_poll_once_inner``).  This function never registers UIDs
-    itself because it is agnostic to folders and IMAP state.  The result is:
-
-    * If this function raises, the UID is still claimed → message is skipped on
-      the next cycle rather than being dispatched twice.  This is intentional.
-    * All early-return paths below are correct without UID re-registration.
+    itself because it is agnostic to folders and IMAP state.
 
     EMAIL-2 — Early-return audit
     ─────────────────────────────
-    Every code path in this function ends in one of:
-      1. return (hard-skip / promotional) — UID already registered, no DB write needed.
-      2. _log_unmatched()                 — UID registered; no client/return found.
-      3. _save_attachments() + _add_note() — UID registered; documents attached.
+    Every code path ends in one of:
+      1. return OUTCOME_SKIP  — hard-skip / promotional / no client match.
+      2. return OUTCOME_SUCCESS — documents attached or note added.
+    Exceptions bubble up to the caller which catches them and returns OUTCOME_RETRY.
     No path can produce a duplicate dispatch.
     """
     classification = msg["classification"]
@@ -305,7 +327,7 @@ def _dispatch_classified_message(app, msg: dict) -> None:
     # Layer 1 hard skip — no DB writes at all
     if source_layer == "known_rule":
         logger.info(f"Hard skip: {sender_domain} — known sender rule")
-        return
+        return OUTCOME_SKIP
 
     # ── Recording policy ─────────────────────────────────────────────────────
     # Record in email_classifications for heuristic / ML / LLM outcomes staff may correct.
@@ -330,11 +352,11 @@ def _dispatch_classified_message(app, msg: dict) -> None:
             )
         if should_update_cache:
             _update_domain_cache(sender_domain, "promotional")
-        return
+        return OUTCOME_SKIP
 
     if classification == "unknown":
         _log_unmatched(app, sender, subject)
-        return
+        return OUTCOME_SKIP
 
     # client_document or client_inquiry ──────────────────────────────────────
     from config import MAIL_LOW_CONF_THRESHOLD
@@ -370,58 +392,179 @@ def _dispatch_classified_message(app, msg: dict) -> None:
     # Drive share — add a note, skip attachment saving
     if _is_drive_share(subject, body_text):
         logger.info(f"Drive share from {sender_domain} — adding note")
-        if name:
-            if client:
-                if is_low_confidence:
-                    logger.info(
-                        f"Drive share low-confidence match score={match_score} "
-                        f"for {name!r} — queued for review (ec_id={ec_id})"
-                    )
-                    return
-                ret = _find_current_return(app, client["id"])
-                if ret:
-                    if _add_note(app, ret["id"], sender, subject, 0, drive_share=True):
-                        if ec_id is not None:
-                            _mark_email_routed_ok(ec_id)
-                else:
-                    _log_unmatched(app, sender, subject)  # EMAIL-2: no open return
-            else:
-                _log_unmatched(app, sender, subject)  # EMAIL-2: client not found
-        else:
-            _log_unmatched(app, sender, subject)  # EMAIL-2: name not extracted
-        return
+        if name and client and not is_low_confidence:
+            ret = _find_current_return(app, client["id"])
+            if ret:
+                if _add_note(app, ret["id"], sender, subject, 0, drive_share=True):
+                    if ec_id is not None:
+                        _mark_email_routed_ok(ec_id)
+                    return OUTCOME_SUCCESS
+            # no open return for this client
+            _log_unmatched(app, sender, subject)  # EMAIL-2: no open return
+            return OUTCOME_SKIP
+        if name and client and is_low_confidence:
+            logger.info(
+                f"Drive share low-confidence match score={match_score} "
+                f"for {name!r} — queued for review (ec_id={ec_id})"
+            )
+            return OUTCOME_SKIP
+        # no name or no client match
+        _log_unmatched(app, sender, subject)  # EMAIL-2: client not found / name not extracted
+        return OUTCOME_SKIP
 
     # Normal attachment + note flow
-    if name:
-        if client:
-            if is_low_confidence:
-                # EMAIL-7: low-confidence — save attachments but mark as pending_review
-                # so staff can confirm/reject before documents are considered authoritative.
-                ret = _find_current_return(app, client["id"])
-                if ret:
-                    count = _save_attachments(
-                        app, message, ret["id"], source="mail_pending_review"
-                    )
-                    logger.info(
-                        f"Low-confidence match score={match_score} for {name!r} "
-                        f"({client['first_name']} {client['last_name']}) — "
-                        f"saved {count} doc(s) as pending_review (ec_id={ec_id})"
-                    )
-                else:
-                    _log_unmatched(app, sender, subject)
-            else:
-                ret = _find_current_return(app, client["id"])
-                if ret:
-                    count = _save_attachments(app, message, ret["id"])
-                    _add_note(app, ret["id"], sender, subject, count)
-                    if ec_id is not None and count > 0:
-                        _mark_email_routed_ok(ec_id)
-                else:
-                    _log_unmatched(app, sender, subject)
-        else:
-            _log_unmatched(app, sender, subject)
-    else:
+    if not name:
         _log_unmatched(app, sender, subject)
+        return OUTCOME_SKIP
+
+    if not client:
+        _log_unmatched(app, sender, subject)
+        return OUTCOME_SKIP
+
+    if is_low_confidence:
+        # EMAIL-7: low-confidence — save attachments but mark as pending_review
+        # so staff can confirm/reject before documents are considered authoritative.
+        ret = _find_current_return(app, client["id"])
+        if not ret:
+            _log_unmatched(app, sender, subject)
+            return OUTCOME_SKIP
+        # Normalize name_matcher score (0–100 int) to 0.0–1.0 for storage
+        _score_norm = round(match_score / 100.0, 4) if match_score is not None else None
+        count = _save_attachments(
+            app, message, ret["id"], source="mail_pending_review",
+            match_score=_score_norm, match_method="fuzzy",
+        )
+        logger.info(
+            f"Low-confidence match score={match_score} for {name!r} "
+            f"({client['first_name']} {client['last_name']}) — "
+            f"saved {count} doc(s) as pending_review (ec_id={ec_id})"
+        )
+        if count > 0:
+            # Boost so future emails from this domain skip the classifier entirely
+            _update_domain_cache(sender_domain, "client_document", boost=True)
+        # count=0 means every attachment was a duplicate — nothing new landed.
+        return OUTCOME_SUCCESS if count > 0 else OUTCOME_SKIP
+
+    # High-confidence client match — attach documents and add note
+    ret = _find_current_return(app, client["id"])
+    if not ret:
+        _log_unmatched(app, sender, subject)
+        return OUTCOME_SKIP
+    _score_norm = round(match_score / 100.0, 4) if match_score is not None else None
+    count = _save_attachments(
+        app, message, ret["id"],
+        match_score=_score_norm, match_method="fuzzy",
+    )
+    _add_note(app, ret["id"], sender, subject, count)
+    if ec_id is not None and count > 0:
+        _mark_email_routed_ok(ec_id)
+    if count > 0:
+        # Boost domain confidence to graduation threshold immediately — one successful
+        # attachment save is enough evidence that this is a real client domain.
+        _update_domain_cache(sender_domain, "client_document", boost=True)
+    # count=0 means every attachment was a duplicate — nothing new landed.
+    return OUTCOME_SUCCESS if count > 0 else OUTCOME_SKIP
+
+
+def _upsert_processing_log(
+    uid_str: str,
+    folder: str,
+    sender_domain: str,
+    subject_snippet: str,
+    outcome: str,
+    error_message: str | None = None,
+    doc_id: int | None = None,
+    return_id: int | None = None,
+) -> None:
+    """Part 4: upsert a row in email_processing_log after each message is processed.
+
+    Natural key: (message_uid, imap_folder).
+    On first attempt: INSERT.  On repeat: UPDATE attempt_count + 1.
+    Subject and error are truncated — never store email body, SSN, or addresses.
+    """
+    from db import get_connection
+    from utils import now
+    try:
+        conn = get_connection()
+        try:
+            conn.execute(
+                """
+                INSERT INTO email_processing_log
+                    (message_uid, imap_folder, sender_domain, subject_snippet,
+                     outcome, attempt_count, last_attempt_at, error_message,
+                     doc_id, return_id)
+                VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?)
+                ON CONFLICT(message_uid, imap_folder) DO UPDATE SET
+                    attempt_count    = attempt_count + 1,
+                    last_attempt_at  = excluded.last_attempt_at,
+                    outcome          = excluded.outcome,
+                    error_message    = excluded.error_message
+                """,
+                (
+                    uid_str[:64],
+                    folder[:128],
+                    (sender_domain or "")[:128],
+                    (subject_snippet or "")[:100],
+                    outcome,
+                    now(),
+                    (error_message or "")[:200] or None,
+                    doc_id,
+                    return_id,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception as exc:
+        logger.error("email_processing_log upsert failed uid=%s: %s", uid_str, exc)
+
+
+def _retry_cap_exceeded(uid_str: str, folder: str) -> bool:
+    """Part 5: return True when attempt_count >= IMAP_MAX_RETRIES for this (uid, folder) pair."""
+    from config import IMAP_MAX_RETRIES
+    from db import get_connection
+    try:
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT attempt_count FROM email_processing_log "
+                "WHERE message_uid = ? AND imap_folder = ?",
+                (uid_str[:64], folder[:128]),
+            ).fetchone()
+        finally:
+            conn.close()
+        if row and row["attempt_count"] >= IMAP_MAX_RETRIES:
+            return True
+    except Exception as exc:
+        logger.error("retry cap check failed uid=%s: %s", uid_str, exc)
+    return False
+
+
+def _already_processed_in_log(uid_str: str, folder: str) -> bool:
+    """Return True when email_processing_log shows a terminal outcome (success/skip)
+    for this (uid, folder) pair.
+
+    Used by IMAP_PRESERVE_UNREAD mode: emails are never marked \\Seen, so the
+    in-process _processed_uids cache can't survive a restart.  This DB check
+    provides restart-safe dedup without relying on IMAP read status.
+    Only success and skip are terminal — retry must be re-attempted.
+    """
+    from db import get_connection
+    try:
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT outcome FROM email_processing_log "
+                "WHERE message_uid = ? AND imap_folder = ?",
+                (uid_str[:64], folder[:128]),
+            ).fetchone()
+        finally:
+            conn.close()
+        if row and row["outcome"] in (OUTCOME_SUCCESS, OUTCOME_SKIP):
+            return True
+    except Exception as exc:
+        logger.error("already_processed check failed uid=%s: %s", uid_str, exc)
+    return False
 
 
 def _poll_once_inner(app) -> None:
@@ -439,11 +582,11 @@ def _poll_once_inner(app) -> None:
     """
     from config import (
         IMAP_HOST, IMAP_PORT, IMAP_USER, IMAP_PASS,
-        IMAP_FOLDER, GMAIL_CATEGORY_FOLDERS, USE_GMAIL_CATEGORIES,
+        IMAP_FOLDERS, GMAIL_CATEGORY_FOLDERS, USE_GMAIL_CATEGORIES,
     )
 
     folders_to_check = GMAIL_CATEGORY_FOLDERS if USE_GMAIL_CATEGORIES else {
-        IMAP_FOLDER: "full_processing"
+        folder: "full_processing" for folder in IMAP_FOLDERS
     }
 
     imap = imaplib.IMAP4_SSL(IMAP_HOST, IMAP_PORT)
@@ -486,14 +629,20 @@ def _poll_once_inner(app) -> None:
                 logger.info(f"No unseen messages in {folder!r}")
                 continue
 
+            from config import IMAP_PRESERVE_UNREAD
             total_unseen = len(raw_uids)
             claimed_uids: list[bytes] = []
             for uid in raw_uids:
                 uid_str = uid.decode("ascii", errors="replace")
-                if _mark_uid_processed(folder, uid_str):
-                    claimed_uids.append(uid)
-                else:
-                    logger.debug(f"UID {uid_str} in {folder} already processed — skipping")
+                if not _mark_uid_processed(folder, uid_str):
+                    logger.debug(f"UID {uid_str} in {folder} already processed (in-process cache) — skipping")
+                    continue
+                # Emails are never marked \Seen, so the in-process cache is lost on
+                # restart.  The DB log is the restart-safe dedup layer — always checked.
+                if _already_processed_in_log(uid_str, folder):
+                    logger.debug(f"UID {uid_str} in {folder} already in processing log — skipping")
+                    continue
+                claimed_uids.append(uid)
 
             already_seen = total_unseen - len(claimed_uids)
             # EMAIL-3: diagnostic counter — shows full funnel per poll cycle
@@ -508,7 +657,9 @@ def _poll_once_inner(app) -> None:
 
             if handling == "skip":
                 for uid in claimed_uids:
-                    _mark_read(imap, uid, f"folder={folder} auto-skip")
+                    uid_str = uid.decode("ascii", errors="replace") if isinstance(uid, bytes) else str(uid)
+                    # READ-STATUS POLICY: never mark as read — log only.
+                    _upsert_processing_log(uid_str, folder, "", "", OUTCOME_SKIP)
                 logger.info(f"Auto-skipped {len(claimed_uids)} message(s) from {folder!r}")
             else:
                 # full_processing — fetch and collect for classification
@@ -525,9 +676,16 @@ def _poll_once_inner(app) -> None:
                                     "source_layer": None,
                                 }
                             )
+                        else:
+                            # Fetch returned None — leave unread for retry
+                            uid_str = uid.decode("ascii", errors="replace") if isinstance(uid, bytes) else str(uid)
+                            logger.warning(f"Fetch returned no data uid={uid_str!r} in {folder!r} — leaving unread for retry")
+                            _upsert_processing_log(uid_str, folder, "", "", OUTCOME_RETRY, "fetch returned no data")
                     except Exception as e:
-                        logger.error(f"Fetch failed uid={uid!r} in {folder!r}: {e}")
-                        _mark_read(imap, uid, "fetch-error")
+                        uid_str = uid.decode("ascii", errors="replace") if isinstance(uid, bytes) else str(uid)
+                        logger.error(f"Fetch failed uid={uid_str!r} in {folder!r}: {e}")
+                        # Part 3: leave unread — fetch failure is retriable
+                        _upsert_processing_log(uid_str, folder, "", "", OUTCOME_RETRY, str(e)[:200])
 
         if not messages:
             return
@@ -543,17 +701,51 @@ def _poll_once_inner(app) -> None:
             msg["source_layer"]   = layer
 
         # ── Phase 3: dispatch each message ────────────────────────────────────
+        # Part 3: _mark_read is called ONLY here, based on the returned outcome.
+        # _dispatch_classified_message never touches IMAP state directly.
         for msg in messages:
-            try:
-                _dispatch_classified_message(app, msg)
-                # Known-rule path skips DB/IMAP-heavy work inside dispatch — still clear UNSEEN.
-                if msg.get("source_layer") == "known_rule":
-                    uid = msg.get("uid")
-                    if uid is not None:
-                        _mark_read(imap, uid, "known-sender-rule")
-            except Exception as e:
-                logger.error(
-                    f"Dispatch failed for {msg.get('sender_domain')}: {e}"
+            uid      = msg.get("uid")
+            uid_str  = uid.decode("ascii", errors="replace") if isinstance(uid, bytes) else str(uid or "")
+            folder   = msg.get("folder", "INBOX")
+            domain   = msg.get("sender_domain") or ""
+            subject  = (msg.get("subject") or "")[:100]
+            err_msg: str | None = None
+
+            # Part 5: max retry cap — prevent permanently broken emails from
+            # blocking an unread slot indefinitely.
+            if _retry_cap_exceeded(uid_str, folder):
+                logger.warning(
+                    f"Max retries exceeded uid={uid_str!r} domain={domain!r} "
+                    f"— marking as read and skipping permanently"
+                )
+                outcome = OUTCOME_SKIP
+            else:
+                try:
+                    outcome = _dispatch_classified_message(app, msg)
+                except Exception as e:
+                    err_msg = str(e)[:200]
+                    logger.error(
+                        f"Dispatch failed uid={uid_str!r} domain={domain!r} "
+                        f"subject={subject!r}: {e}"
+                    )
+                    outcome = OUTCOME_RETRY
+
+            # Part 4: log every outcome regardless of success or failure
+            _upsert_processing_log(uid_str, folder, domain, subject, outcome, err_msg)
+
+            # READ-STATUS POLICY: TaxOps NEVER marks emails as read.
+            # - BODY.PEEK[] on fetch prevents the IMAP server auto-setting \Seen.
+            # - _mark_read is never called here; staff review all mail in Gmail.
+            # - Dedup is handled by email_processing_log + in-process UID cache.
+            if outcome == OUTCOME_RETRY:
+                logger.warning(
+                    f"Message left unread for retry uid={uid_str!r} domain={domain!r}"
+                )
+            elif outcome == OUTCOME_DRY_RUN:
+                logger.info(f"DRY RUN uid={uid_str!r} — no IMAP state changed")
+            else:
+                logger.info(
+                    f"Processed uid={uid_str!r} outcome={outcome} — left unread"
                 )
 
     finally:
@@ -911,6 +1103,7 @@ def _classify_email(domain: str, subject: str, body_text: str = "") -> tuple:
         return cls, "keyword"
 
     # Layer 5: domain_classifications cache (any confidence)
+    # Boosted client domains land here after their first successful attachment save.
     cached = _get_cached_domain(domain)
     if cached:
         logger.info(
@@ -919,13 +1112,41 @@ def _classify_email(domain: str, subject: str, body_text: str = "") -> tuple:
         )
         return cached["classification"], "cache"
 
-    # Layer 5.5: sklearn classifier (trained on confirmed staff data)
+    # Layer 5.3: client hint domains — unique business domains that will never appear
+    # in a generic spam training set.  Bypass the ML classifier and go straight to LLM.
+    # After the first successful save the domain is boosted into cache (Layer 5).
+    from config import CLIENT_HINT_DOMAINS
+    if CLIENT_HINT_DOMAINS:
+        _hint_base = ".".join(domain.split(".")[-2:]) if len(domain.split(".")) >= 2 else domain
+        if _hint_base in CLIENT_HINT_DOMAINS or domain in CLIENT_HINT_DOMAINS:
+            logger.info(f"Client hint domain {domain!r} — skipping ML classifier, routing to LLM")
+            cls = _classify_domain_llm(domain, [subject])
+            _update_domain_cache(domain, cls)
+            return cls, "llm"
+
+    # Layer 5.5: sklearn classifier with asymmetric confidence thresholds.
+    # classify_raw() returns label+confidence without applying any internal threshold
+    # so we can apply different bars for promotional vs client classifications.
+    # Promotional requires higher confidence because a false-positive silently drops
+    # a client email; a false-positive client classification only costs a staff review.
     try:
-        from classifier import classify as _ml_classify
-        ml_cls, _ml_conf = _ml_classify(subject, domain, body_text[:200])
+        from classifier import classify_raw as _ml_classify_raw
+        from config import CLASSIFIER_CLIENT_THRESHOLD, CLASSIFIER_PROMOTIONAL_THRESHOLD
+        ml_cls, ml_conf = _ml_classify_raw(subject, domain, body_text[:200])
         if ml_cls is not None:
-            _update_domain_cache(domain, ml_cls)
-            return ml_cls, "ml"
+            if ml_cls == "promotional" and ml_conf >= CLASSIFIER_PROMOTIONAL_THRESHOLD:
+                logger.info(f"Classifier: {domain!r} → {ml_cls} ({ml_conf:.2f})")
+                _update_domain_cache(domain, ml_cls)
+                return ml_cls, "ml"
+            elif ml_cls in ("client_document", "client_inquiry") and ml_conf >= CLASSIFIER_CLIENT_THRESHOLD:
+                logger.info(f"Classifier: {domain!r} → {ml_cls} ({ml_conf:.2f})")
+                _update_domain_cache(domain, ml_cls)
+                return ml_cls, "ml"
+            else:
+                logger.info(
+                    f"Classifier {ml_cls} at {ml_conf:.2f} below asymmetric threshold "
+                    f"for {domain!r} — falling through to LLM"
+                )
     except Exception as _ml_err:
         logger.debug(f"ML layer skipped for {domain}: {_ml_err}")
 
@@ -947,10 +1168,16 @@ def _get_domain_classification(
     return _classify_email(domain, subject, body_preview)
 
 
-def _update_domain_cache(domain: str, classification: str) -> None:
+def _update_domain_cache(domain: str, classification: str, boost: bool = False) -> None:
     """
     Upsert domain_classifications — increment confidence if same classification,
     reset to 1 if classification changed.
+
+    boost=True: set confidence_count to the graduation threshold (3) immediately
+    rather than incrementing by 1.  Used after a confirmed client attachment save
+    so the domain graduates to a rule suggestion after a single successful email.
+    If the domain already has count >= 3, boost is a no-op on count.
+
     After updating, check whether this domain qualifies for graduation.
     Never raises.
     """
@@ -967,27 +1194,39 @@ def _update_domain_cache(domain: str, classification: str) -> None:
                 (domain,),
             ).fetchone()
 
+            # Graduation threshold — must match _check_graduation_trigger
+            _GRAD_THRESHOLD = 3
+
             if existing:
                 if existing["classification"] == classification:
-                    conn.execute(
-                        "UPDATE domain_classifications "
-                        "SET confidence_count = confidence_count + 1, last_seen = ? "
-                        "WHERE domain = ? COLLATE NOCASE",
-                        (now(), domain),
-                    )
+                    if boost:
+                        conn.execute(
+                            "UPDATE domain_classifications "
+                            "SET confidence_count = MAX(confidence_count, ?), last_seen = ? "
+                            "WHERE domain = ? COLLATE NOCASE",
+                            (_GRAD_THRESHOLD, now(), domain),
+                        )
+                    else:
+                        conn.execute(
+                            "UPDATE domain_classifications "
+                            "SET confidence_count = confidence_count + 1, last_seen = ? "
+                            "WHERE domain = ? COLLATE NOCASE",
+                            (now(), domain),
+                        )
                 else:
+                    # Classification changed — reset count (boost still jumps to threshold)
                     conn.execute(
                         "UPDATE domain_classifications "
-                        "SET classification = ?, confidence_count = 1, last_seen = ? "
+                        "SET classification = ?, confidence_count = ?, last_seen = ? "
                         "WHERE domain = ? COLLATE NOCASE",
-                        (classification, now(), domain),
+                        (classification, _GRAD_THRESHOLD if boost else 1, now(), domain),
                     )
             else:
                 conn.execute(
                     "INSERT INTO domain_classifications "
                     "(domain, classification, confidence_count, last_seen) "
-                    "VALUES (?, ?, 1, ?)",
-                    (domain, classification, now()),
+                    "VALUES (?, ?, ?, ?)",
+                    (domain, classification, _GRAD_THRESHOLD if boost else 1, now()),
                 )
             conn.commit()
         finally:
@@ -996,7 +1235,8 @@ def _update_domain_cache(domain: str, classification: str) -> None:
         logger.error(f"_update_domain_cache failed for {domain}: {e}")
         return
 
-    # Trigger graduation check in the same call (fast — just DB reads/writes)
+    # Trigger graduation check — always synchronous (pure DB reads/writes, fast).
+    # boost=True guarantees count >= threshold so graduation fires immediately.
     _check_graduation_trigger(None, domain)
 
 
@@ -1549,7 +1789,9 @@ def _find_current_return(app, client_id: int) -> dict | None:
 # ── Attachment saving ─────────────────────────────────────────────────────────
 
 def _save_attachments(
-    app, message, return_id: int, source: str = "email"
+    app, message, return_id: int, source: str = "email",
+    match_score: float | None = None,
+    match_method: str | None = None,
 ) -> int:
     """Walk MIME parts, save allowed attachments (pdf/jpg/jpeg/png) to disk,
     and record each in return_documents.
@@ -1679,8 +1921,9 @@ def _save_attachments(
                     """
                     INSERT INTO return_documents (
                         return_id, filename, original_filename, doc_type, source,
-                        file_path, file_size_bytes, file_hash, uploaded_by, uploaded_at, notes, is_deleted
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
+                        file_path, file_size_bytes, file_hash, uploaded_by, uploaded_at, notes, is_deleted,
+                        match_confirmed, match_score, match_method
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, ?, ?)
                     """,
                     (
                         return_id,
@@ -1694,6 +1937,9 @@ def _save_attachments(
                         "mail_watcher",
                         uploaded_at,
                         None,
+                        # match_confirmed=0: all email matches need staff confirmation
+                        match_score,
+                        match_method,
                     ),
                 )
                 new_doc_id = cur.lastrowid

--- a/taxops/routes/reports.py
+++ b/taxops/routes/reports.py
@@ -1,0 +1,249 @@
+"""Reports Blueprint — season summary, preparer performance, return mix.
+
+Routes
+------
+GET  /reports             — HTML reports page (cache-first)
+GET  /api/reports/data    — JSON report data for ?year=N (no reload)
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date
+
+from flask import Blueprint, jsonify, render_template, request
+
+from auth import login_required
+from db import get_connection
+
+logger = logging.getLogger(__name__)
+
+reports_bp = Blueprint("reports", __name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — all queries JOIN payments; never expose ssn / ssn_last4
+# ---------------------------------------------------------------------------
+
+def _season_summary(conn, year: int) -> dict:
+    """Section A: total billed, collected, outstanding, rates."""
+    row = conn.execute(
+        """
+        SELECT
+            COUNT(r.id) AS return_count,
+            COALESCE(SUM(p.total_fee), 0)                                   AS total_billed,
+            COALESCE(SUM(p.fee_paid),  0)                                   AS total_collected,
+            COALESCE(SUM(
+                CASE WHEN COALESCE(p.total_fee,0) > COALESCE(p.fee_paid,0)
+                     THEN COALESCE(p.total_fee,0) - COALESCE(p.fee_paid,0)
+                     ELSE 0 END
+            ), 0)                                                            AS total_outstanding,
+            COUNT(CASE WHEN COALESCE(p.fee_paid,0) >= COALESCE(p.total_fee,0)
+                            AND COALESCE(p.total_fee,0) > 0
+                       THEN 1 END)                                           AS fully_paid_count,
+            COUNT(CASE WHEN COALESCE(p.fee_paid,0) < COALESCE(p.total_fee,0)
+                            AND COALESCE(p.total_fee,0) > 0
+                       THEN 1 END)                                           AS balance_due_count,
+            ROUND(AVG(CASE WHEN COALESCE(p.total_fee,0) > 0
+                           THEN p.total_fee END), 2)                         AS avg_fee
+        FROM returns r
+        LEFT JOIN payments p ON p.return_id = r.id
+        WHERE r.tax_year = ?
+          AND UPPER(COALESCE(r.client_status, '')) != 'CANCELLED'
+        """,
+        (year,),
+    ).fetchone()
+    if not row:
+        return {}
+    d = dict(row)
+    billed = d.get("total_billed") or 0
+    collected = d.get("total_collected") or 0
+    d["collection_rate"] = round(collected / billed * 100, 1) if billed else 0.0
+    return d
+
+
+def _season_summary_yoy(conn, year: int) -> dict:
+    """Section A with YoY deltas for billed and avg_fee."""
+    curr = _season_summary(conn, year)
+    prev = _season_summary(conn, year - 1)
+
+    def _delta(key: str) -> float | None:
+        c = curr.get(key) or 0.0
+        p = prev.get(key) or 0.0
+        if not p:
+            return None
+        return round((c - p) / p * 100, 1)
+
+    curr["yoy_billed_pct"] = _delta("total_billed")
+    curr["yoy_avg_fee_pct"] = _delta("avg_fee")
+    curr["prev_year"] = year - 1
+    curr["prev_total_billed"] = prev.get("total_billed", 0)
+    return curr
+
+
+def _preparer_performance(conn, year: int) -> list[dict]:
+    """Section B: per-preparer stats."""
+    rows = conn.execute(
+        """
+        SELECT
+            r.processor,
+            COUNT(r.id)                                                         AS return_count,
+            ROUND(AVG(CASE WHEN COALESCE(p.total_fee,0) > 0
+                           THEN p.total_fee END), 2)                            AS avg_fee,
+            COALESCE(SUM(p.total_fee), 0)                                       AS total_billed,
+            COALESCE(SUM(p.fee_paid),  0)                                       AS total_collected,
+            COUNT(CASE WHEN r.client_status = 'LOG OUT'                  THEN 1 END) AS completed_count,
+            COUNT(CASE WHEN r.client_status IN ('PROCESSING','HOLD','FINALIZE') THEN 1 END) AS in_progress_count
+        FROM returns r
+        LEFT JOIN payments p ON p.return_id = r.id
+        WHERE r.tax_year = ?
+          AND UPPER(COALESCE(r.client_status, '')) != 'CANCELLED'
+          AND r.processor IS NOT NULL
+        GROUP BY r.processor
+        ORDER BY return_count DESC
+        """,
+        (year,),
+    ).fetchall()
+    result = [dict(r) for r in rows]
+    total = sum(r["return_count"] for r in result)
+    for r in result:
+        r["share_pct"] = round(r["return_count"] / total * 100, 1) if total else 0.0
+    return result
+
+
+def _return_mix(conn, year: int) -> dict:
+    """Section C: status breakdown, fee ranges, YoY table."""
+    # -- by status --
+    by_status_rows = conn.execute(
+        """
+        SELECT r.client_status, COUNT(*) AS count
+        FROM returns r
+        WHERE r.tax_year = ?
+          AND UPPER(COALESCE(r.client_status, '')) != 'CANCELLED'
+        GROUP BY r.client_status
+        ORDER BY count DESC
+        """,
+        (year,),
+    ).fetchall()
+
+    # -- by fee range --
+    by_fee_rows = conn.execute(
+        """
+        SELECT
+            CASE
+                WHEN COALESCE(p.total_fee, 0) = 0   THEN 'No fee'
+                WHEN p.total_fee < 200              THEN 'Under $200'
+                WHEN p.total_fee < 400              THEN '$200 – $399'
+                WHEN p.total_fee < 600              THEN '$400 – $599'
+                WHEN p.total_fee < 1000             THEN '$600 – $999'
+                ELSE '$1,000+'
+            END AS fee_range,
+            COUNT(*) AS count,
+            ROUND(AVG(CASE WHEN COALESCE(p.total_fee,0) > 0 THEN p.total_fee END), 2) AS avg_fee,
+            MIN(COALESCE(p.total_fee, 0)) AS min_fee
+        FROM returns r
+        LEFT JOIN payments p ON p.return_id = r.id
+        WHERE r.tax_year = ?
+          AND UPPER(COALESCE(r.client_status, '')) != 'CANCELLED'
+        GROUP BY fee_range
+        ORDER BY min_fee
+        """,
+        (year,),
+    ).fetchall()
+
+    # -- YoY (last 5 seasons) --
+    yoy_rows = conn.execute(
+        """
+        SELECT
+            r.tax_year,
+            COUNT(*) AS count,
+            ROUND(AVG(CASE WHEN COALESCE(p.total_fee,0) > 0 THEN p.total_fee END), 2) AS avg_fee
+        FROM returns r
+        LEFT JOIN payments p ON p.return_id = r.id
+        WHERE UPPER(COALESCE(r.client_status, '')) != 'CANCELLED'
+        GROUP BY r.tax_year
+        ORDER BY r.tax_year DESC
+        LIMIT 5
+        """,
+    ).fetchall()
+
+    status_list = [dict(r) for r in by_status_rows]
+    total_status = sum(r["count"] for r in status_list)
+    for r in status_list:
+        r["pct"] = round(r["count"] / total_status * 100, 1) if total_status else 0.0
+
+    fee_list = [dict(r) for r in by_fee_rows]
+    total_fee_count = sum(r["count"] for r in fee_list)
+    for r in fee_list:
+        r["pct"] = round(r["count"] / total_fee_count * 100, 1) if total_fee_count else 0.0
+
+    return {
+        "by_status": status_list,
+        "by_fee_range": fee_list,
+        "yoy": [dict(r) for r in yoy_rows],
+    }
+
+
+def _available_years(conn) -> list[int]:
+    rows = conn.execute(
+        "SELECT DISTINCT tax_year FROM returns WHERE tax_year IS NOT NULL ORDER BY tax_year DESC LIMIT 10"
+    ).fetchall()
+    return [r["tax_year"] for r in rows]
+
+
+def _build_report_data(year: int) -> dict:
+    """Assemble full report dict for the given year.
+
+    Reads cache first for financial stats; falls back to direct DB queries.
+    Never exposes ssn, ssn_last4, or identification numbers.
+    """
+    from chat_cache import get_cache_year, get_financial_stats, is_cache_warm
+
+    conn = get_connection()
+    try:
+        summary = _season_summary_yoy(conn, year)
+        preparers = _preparer_performance(conn, year)
+        mix = _return_mix(conn, year)
+        years = _available_years(conn)
+    finally:
+        conn.close()
+
+    cache_warm = is_cache_warm() and get_cache_year() == year
+    cached_fin = get_financial_stats() if cache_warm else {}
+
+    return {
+        "year": year,
+        "available_years": years,
+        "summary": summary,
+        "preparers": preparers,
+        "mix": mix,
+        "cache_warm": cache_warm,
+        "cached_financial": cached_fin,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@reports_bp.route("/reports")
+@login_required
+def reports():
+    year = int(request.args.get("year", date.today().year))
+    data = _build_report_data(year)
+    from app import base_ctx  # lazy — avoids circular import at module level
+    ctx = base_ctx(year)
+    ctx.update({
+        "active_page":  "reports",
+        "report":       data,
+        "report_year":  year,
+        "as_of_date":   date.today().strftime("%B %Y"),
+    })
+    return render_template("reports.html", **ctx)
+
+
+@reports_bp.route("/api/reports/data")
+@login_required
+def api_reports_data():
+    """JSON endpoint for year-picker AJAX refresh. Never returns ssn fields."""
+    year = int(request.args.get("year", date.today().year))
+    return jsonify(_build_report_data(year))

--- a/taxops/templates/base.html
+++ b/taxops/templates/base.html
@@ -48,6 +48,10 @@
           {{ _('Dashboard') }}
         </a>
 
+        <a href="/reports?year={{ current_year }}" class="nav-link {% if active_page == 'reports' %}active{% endif %}">
+          {{ _('Reports') }}
+        </a>
+
         <!-- Tools dropdown (queues & utility pages consolidated to free header space for search) -->
         {% set tools_active =
             active_page in ('upload','source_compare','import_audit','merge','efile_batch','audit_log',

--- a/taxops/templates/reports.html
+++ b/taxops/templates/reports.html
@@ -1,0 +1,331 @@
+{% extends "base.html" %}
+{% block title %}{{ _('Reports') }} — TaxOps {{ report_year }}{% endblock %}
+
+{% block content %}
+<div class="max-w-screen-2xl mx-auto px-4 py-6 space-y-6">
+
+  <!-- ── Header row: title + year picker + print ───────────────────────── -->
+  <div class="flex items-center justify-between gap-4 flex-wrap">
+    <h1 class="text-xl font-bold text-slate-900">{{ _('Season Reports') }}</h1>
+
+    <div class="flex items-center gap-3">
+      <!-- Year picker pills -->
+      <nav class="flex items-center gap-1" aria-label="{{ _('Tax year') }}">
+        {% for y in report.available_years %}
+        <a href="/reports?year={{ y }}"
+           id="year-pill-{{ y }}"
+           class="pill shrink-0 {% if y == report_year %}pill-active{% else %}pill-inactive{% endif %}">
+          {{ y }}
+        </a>
+        {% endfor %}
+      </nav>
+
+      <!-- Print -->
+      <button onclick="window.print()"
+              class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-slate-200 bg-white text-sm text-slate-600 hover:bg-slate-50 transition-colors shadow-sm print:hidden">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 9V3h12v6M6 18H4a1 1 0 01-1-1v-5a1 1 0 011-1h16a1 1 0 011 1v5a1 1 0 01-1 1h-2M6 14h12v7H6v-7z"/>
+        </svg>
+        {{ _('Print') }}
+      </button>
+    </div>
+  </div>
+
+  <!-- ── Section A: Season summary KPI cards ───────────────────────────── -->
+  {% set s = report.summary %}
+  <section aria-labelledby="summary-heading">
+    <h2 id="summary-heading" class="text-sm font-semibold text-slate-500 uppercase tracking-wide mb-3">{{ _('Season Summary') }}</h2>
+
+    <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
+
+      <!-- Total Billed -->
+      <div class="bg-white rounded-xl border border-slate-200 shadow-sm p-4">
+        <p class="text-xs font-medium text-slate-500 uppercase tracking-wide mb-1">{{ _('Total Billed') }}</p>
+        <p class="text-2xl font-bold text-slate-900 tabular-nums">${{ "{:,.0f}".format(s.total_billed or 0) }}</p>
+        {% if s.yoy_billed_pct is not none %}
+        <p class="mt-1 text-xs font-semibold {{ 'text-green-600' if s.yoy_billed_pct >= 0 else 'text-red-500' }}">
+          {{ '+' if s.yoy_billed_pct >= 0 else '' }}{{ s.yoy_billed_pct }}%
+          <span class="font-normal text-slate-400">vs {{ s.prev_year }}</span>
+        </p>
+        {% endif %}
+      </div>
+
+      <!-- Total Collected -->
+      <div class="bg-white rounded-xl border border-slate-200 shadow-sm p-4">
+        <p class="text-xs font-medium text-slate-500 uppercase tracking-wide mb-1">{{ _('Total Collected') }}</p>
+        <p class="text-2xl font-bold text-green-700 tabular-nums">${{ "{:,.0f}".format(s.total_collected or 0) }}</p>
+        <p class="mt-1 text-xs text-slate-500">
+          {{ _('Collection rate:') }}
+          <span class="font-semibold text-slate-700">{{ s.collection_rate or 0 }}%</span>
+        </p>
+      </div>
+
+      <!-- Outstanding -->
+      <div class="bg-white rounded-xl border border-slate-200 shadow-sm p-4">
+        <p class="text-xs font-medium text-slate-500 uppercase tracking-wide mb-1">{{ _('Outstanding Balance') }}</p>
+        <p class="text-2xl font-bold {{ 'text-red-600' if (s.total_outstanding or 0) > 0 else 'text-slate-900' }} tabular-nums">
+          ${{ "{:,.0f}".format(s.total_outstanding or 0) }}
+        </p>
+        <p class="mt-1 text-xs text-slate-500">
+          <span class="font-semibold text-slate-700">{{ s.balance_due_count or 0 }}</span> {{ _('returns') }}
+        </p>
+      </div>
+
+      <!-- Average Fee -->
+      <div class="bg-white rounded-xl border border-slate-200 shadow-sm p-4">
+        <p class="text-xs font-medium text-slate-500 uppercase tracking-wide mb-1">{{ _('Average Fee') }}</p>
+        <p class="text-2xl font-bold text-slate-900 tabular-nums">
+          ${{ "{:,.0f}".format(s.avg_fee or 0) }}
+        </p>
+        {% if s.yoy_avg_fee_pct is not none %}
+        <p class="mt-1 text-xs font-semibold {{ 'text-green-600' if s.yoy_avg_fee_pct >= 0 else 'text-red-500' }}">
+          {{ '+' if s.yoy_avg_fee_pct >= 0 else '' }}{{ s.yoy_avg_fee_pct }}%
+          <span class="font-normal text-slate-400">vs {{ s.prev_year }}</span>
+        </p>
+        {% endif %}
+      </div>
+
+    </div>
+
+    <!-- Summary sentence -->
+    <p class="mt-3 text-sm text-slate-500">
+      {{ _('As of') }} {{ as_of_date }} ·
+      <span class="font-semibold text-slate-700">{{ s.return_count or 0 }}</span> {{ _('returns') }} ·
+      {{ report_year }} {{ _('tax season') }}
+    </p>
+  </section>
+
+  <!-- ── Section B: Preparer performance ───────────────────────────────── -->
+  <section aria-labelledby="preparer-heading">
+    <h2 id="preparer-heading" class="text-sm font-semibold text-slate-500 uppercase tracking-wide mb-3">{{ _('Preparer Performance') }}</h2>
+
+    <div class="bg-white rounded-xl border border-slate-200 shadow-sm overflow-hidden">
+      <table class="w-full text-sm" id="preparer-table">
+        <thead>
+          <tr class="border-b border-slate-100">
+            <th class="th text-left sortable cursor-pointer select-none" data-col="0" data-type="str">{{ _('Preparer') }} <span class="sort-arrow"></span></th>
+            <th class="th text-right sortable cursor-pointer select-none" data-col="1" data-type="num">{{ _('Returns') }} <span class="sort-arrow"></span></th>
+            <th class="th text-right sortable cursor-pointer select-none" data-col="2" data-type="num">{{ _('Avg Fee') }} <span class="sort-arrow"></span></th>
+            <th class="th text-right sortable cursor-pointer select-none" data-col="3" data-type="num">{{ _('Total Billed') }} <span class="sort-arrow"></span></th>
+            <th class="th text-right sortable cursor-pointer select-none" data-col="4" data-type="num">{{ _('Completed') }} <span class="sort-arrow"></span></th>
+            <th class="th text-right sortable cursor-pointer select-none" data-col="5" data-type="num">{{ _('In Progress') }} <span class="sort-arrow"></span></th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          {% for p in report.preparers %}
+          <tr class="hover:bg-slate-50 transition-colors">
+            <td class="td">
+              <div class="font-medium text-slate-800">{{ p.processor }}</div>
+              <!-- Share bar -->
+              <div class="mt-1 h-1.5 w-full bg-slate-100 rounded-full overflow-hidden">
+                <div class="h-full bg-blue-400 rounded-full" style="width: {{ p.share_pct }}%"></div>
+              </div>
+              <div class="mt-0.5 text-xs text-slate-400">{{ p.share_pct }}% {{ _('of total') }}</div>
+            </td>
+            <td class="td text-right font-semibold tabular-nums">{{ p.return_count }}</td>
+            <td class="td text-right tabular-nums">${{ "{:,.0f}".format(p.avg_fee or 0) }}</td>
+            <td class="td text-right tabular-nums">${{ "{:,.0f}".format(p.total_billed or 0) }}</td>
+            <td class="td text-right tabular-nums">{{ p.completed_count }}</td>
+            <td class="td text-right tabular-nums">{{ p.in_progress_count }}</td>
+          </tr>
+          {% else %}
+          <tr>
+            <td colspan="6" class="td text-center text-slate-400 py-6">{{ _('No preparer data for this season.') }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- ── Section C: Return mix ─────────────────────────────────────────── -->
+  <section aria-labelledby="mix-heading">
+    <h2 id="mix-heading" class="text-sm font-semibold text-slate-500 uppercase tracking-wide mb-3">{{ _('Return Mix') }}</h2>
+
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+
+      <!-- Status breakdown -->
+      <div class="bg-white rounded-xl border border-slate-200 shadow-sm overflow-hidden">
+        <div class="px-4 py-3 border-b border-slate-100">
+          <h3 class="text-sm font-semibold text-slate-700">{{ _('By Status') }}</h3>
+        </div>
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-slate-100">
+              <th class="th text-left">{{ _('Status') }}</th>
+              <th class="th text-right">{{ _('Count') }}</th>
+              <th class="th text-right">{{ _('% of Total') }}</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-slate-100">
+            {% for row in report.mix.by_status %}
+            <tr class="hover:bg-slate-50 transition-colors">
+              <td class="td">
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border
+                             {{ status_badge.get(row.client_status, 'bg-slate-100 text-slate-500 border-slate-200') }}">
+                  {{ row.client_status }}
+                </span>
+              </td>
+              <td class="td text-right font-semibold tabular-nums">{{ row.count }}</td>
+              <td class="td text-right tabular-nums text-slate-500">{{ row.pct }}%</td>
+            </tr>
+            {% else %}
+            <tr>
+              <td colspan="3" class="td text-center text-slate-400 py-4">{{ _('No data.') }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Fee range breakdown -->
+      <div class="bg-white rounded-xl border border-slate-200 shadow-sm overflow-hidden">
+        <div class="px-4 py-3 border-b border-slate-100">
+          <h3 class="text-sm font-semibold text-slate-700">{{ _('By Fee Range') }}</h3>
+        </div>
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-slate-100">
+              <th class="th text-left">{{ _('Range') }}</th>
+              <th class="th text-right">{{ _('Count') }}</th>
+              <th class="th text-right">{{ _('Avg Fee') }}</th>
+              <th class="th text-right">{{ _('%') }}</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-slate-100">
+            {% for row in report.mix.by_fee_range %}
+            <tr class="hover:bg-slate-50 transition-colors">
+              <td class="td font-medium text-slate-700">{{ row.fee_range }}</td>
+              <td class="td text-right tabular-nums font-semibold">{{ row.count }}</td>
+              <td class="td text-right tabular-nums text-slate-600">${{ "{:,.0f}".format(row.avg_fee or 0) }}</td>
+              <td class="td text-right tabular-nums text-slate-500">{{ row.pct }}%</td>
+            </tr>
+            {% else %}
+            <tr>
+              <td colspan="4" class="td text-center text-slate-400 py-4">{{ _('No data.') }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+
+    </div>
+
+    <!-- Year-over-year table -->
+    <div class="mt-4 bg-white rounded-xl border border-slate-200 shadow-sm overflow-hidden">
+      <div class="px-4 py-3 border-b border-slate-100">
+        <h3 class="text-sm font-semibold text-slate-700">{{ _('Year-over-Year') }}</h3>
+      </div>
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-slate-100">
+            <th class="th text-left">{{ _('Year') }}</th>
+            <th class="th text-right">{{ _('Returns') }}</th>
+            <th class="th text-right">{{ _('Avg Fee') }}</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          {% for row in report.mix.yoy %}
+          <tr class="hover:bg-slate-50 transition-colors {% if row.tax_year == report_year %}bg-blue-50{% endif %}">
+            <td class="td font-semibold {{ 'text-blue-700' if row.tax_year == report_year else 'text-slate-700' }}">
+              {{ row.tax_year }}
+              {% if row.tax_year == report_year %}<span class="ml-1 text-xs font-normal text-blue-500">{{ _('current') }}</span>{% endif %}
+            </td>
+            <td class="td text-right tabular-nums font-semibold">{{ row.count }}</td>
+            <td class="td text-right tabular-nums text-slate-600">${{ "{:,.0f}".format(row.avg_fee or 0) }}</td>
+          </tr>
+          {% else %}
+          <tr>
+            <td colspan="3" class="td text-center text-slate-400 py-4">{{ _('No data.') }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+</div>
+
+<style>
+  @media print {
+    header, nav, .print\:hidden { display: none !important; }
+    body { background: white; }
+    .rounded-xl { border-radius: 0; }
+    .shadow-sm { box-shadow: none; }
+  }
+</style>
+
+<script>
+(function () {
+  "use strict";
+
+  // ── Year picker: AJAX refresh without full page reload ────────────────
+  document.querySelectorAll('[id^="year-pill-"]').forEach(function (pill) {
+    pill.addEventListener("click", function (e) {
+      e.preventDefault();
+      var year = parseInt(pill.id.replace("year-pill-", ""), 10);
+      history.pushState({year: year}, "", "/reports?year=" + year);
+      _loadReportYear(year);
+    });
+  });
+
+  function _loadReportYear(year) {
+    fetch("/api/reports/data?year=" + year, {credentials: "same-origin"})
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        // Update year pill active state
+        document.querySelectorAll('[id^="year-pill-"]').forEach(function (p) {
+          var y = parseInt(p.id.replace("year-pill-", ""), 10);
+          p.classList.toggle("pill-active", y === year);
+          p.classList.toggle("pill-inactive", y !== year);
+        });
+        // Full page reload is acceptable for now since template drives layout.
+        // For a true no-reload update the whole page is re-rendered server-side.
+        window.location.href = "/reports?year=" + year;
+      })
+      .catch(function () {
+        window.location.href = "/reports?year=" + year;
+      });
+  }
+
+  // ── Preparer table sort ───────────────────────────────────────────────
+  (function () {
+    var table = document.getElementById("preparer-table");
+    if (!table) return;
+    var sortState = {col: -1, asc: true};
+
+    table.querySelectorAll("th.sortable").forEach(function (th) {
+      th.addEventListener("click", function () {
+        var col = parseInt(th.dataset.col, 10);
+        var type = th.dataset.type || "str";
+        if (sortState.col === col) {
+          sortState.asc = !sortState.asc;
+        } else {
+          sortState.col = col;
+          sortState.asc = true;
+        }
+        // Update arrows
+        table.querySelectorAll("th.sortable .sort-arrow").forEach(function (a) { a.textContent = ""; });
+        th.querySelector(".sort-arrow").textContent = sortState.asc ? " ▲" : " ▼";
+
+        var tbody = table.querySelector("tbody");
+        var rows = Array.from(tbody.querySelectorAll("tr"));
+        rows.sort(function (a, b) {
+          var ac = (a.cells[col] && a.cells[col].dataset && a.cells[col].dataset.val)
+            ? a.cells[col].dataset.val
+            : (a.cells[col] ? a.cells[col].textContent.replace(/[$,%]/g, "").trim() : "");
+          var bc = (b.cells[col] && b.cells[col].dataset && b.cells[col].dataset.val)
+            ? b.cells[col].dataset.val
+            : (b.cells[col] ? b.cells[col].textContent.replace(/[$,%]/g, "").trim() : "");
+          var cmp = type === "num"
+            ? (parseFloat(ac) || 0) - (parseFloat(bc) || 0)
+            : ac.localeCompare(bc);
+          return sortState.asc ? cmp : -cmp;
+        });
+        rows.forEach(function (r) { tbody.appendChild(r); });
+      });
+    });
+  }());
+}());
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary

- **Reports page** (`GET /reports`, `GET /api/reports/data`) — new Blueprint with three sections: season KPI cards with YoY deltas, preparer performance table with share bars, and return-mix status/fee-range/YoY breakdown. Year-picker reloads data via AJAX. Print-friendly via `@media print`. Reports nav link added to `base.html`.
- **Unified bulk-update endpoint** (`POST /api/returns/bulk-update`) — accepts `{return_ids, status?, processor?}` in one transaction; at least one field required; max 500 IDs per call; delegates to existing audited bulk helpers.
- **IMAP multi-folder** — `IMAP_FOLDERS` comma-separated env var (defaults to `IMAP_FOLDER`); `mail_watcher` non-Gmail path iterates the list; `_safe_select` now RFC-3501-quotes folder names containing spaces (e.g. `TAX DOCUMENTS FROM CLIENTS`).

## Test plan

- [ ] Visit `/reports?year=2025` — confirm three sections render with live data
- [ ] Click a different year pill — confirm data reloads without full page reload
- [ ] Click Print — confirm nav is hidden, only report content prints
- [ ] On dashboard, check 3 returns → bulk action bar appears → change status to HOLD → confirm all 3 updated and audit log shows 3 entries
- [ ] `POST /api/returns/bulk-update` with `{return_ids:[…], status:"PICKUP", processor:"Alice"}` — confirm both fields updated in one call
- [ ] Set `IMAP_FOLDERS=INBOX,TAX DOCUMENTS FROM CLIENTS` in NSSM and confirm mail watcher polls both folders
- [ ] `python -m pytest tests/ -v` — 494 passed
